### PR TITLE
#264, mark exactly the role of sharding server

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDBPool.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDBPool.java
@@ -214,7 +214,7 @@ public class PhysicalDBPool {
                 break;
             }
         }
-        islave = (currentIndex == activeIndex);
+        islave = (currentIndex != activeIndex);
 
         return islave;
     }


### PR DESCRIPTION
Reason: 
        mark falsely the role of sharding server.
type:
        debug
Influences:
        heartbeat detect and the relation of master and slave