### PR TITLE
#276 Kill @@connection send kill command to backend connection

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/response/KillConnection.java
+++ b/src/main/java/com/actiontech/dble/manager/response/KillConnection.java
@@ -31,10 +31,10 @@ public final class KillConnection {
         int count = 0;
         List<FrontendConnection> list = getList(stmt, offset, mc);
         if (list != null) {
-            for (NIOConnection c : list) {
+            for (FrontendConnection c : list) {
                 StringBuilder s = new StringBuilder();
                 LOGGER.warn(s.append(c).append("killed by manager").toString());
-                c.close("kill by manager");
+                c.killAndClose("kill by manager");
                 count++;
             }
         }

--- a/src/main/java/com/actiontech/dble/net/FrontendConnection.java
+++ b/src/main/java/com/actiontech/dble/net/FrontendConnection.java
@@ -508,4 +508,8 @@ public abstract class FrontendConnection extends AbstractConnection {
     public void close(String reason) {
         super.close(isAuthenticated ? reason : "");
     }
+
+    public void killAndClose(String reaseon){
+
+    }
 }

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -497,37 +497,35 @@ public class NonBlockingSession implements Session {
     }
 
     protected void kill() {
-        boolean hooked = false;
-        AtomicInteger count = null;
-        Map<RouteResultsetNode, BackendConnection> killees = null;
+        AtomicInteger count =new AtomicInteger(0);
+        Map<RouteResultsetNode, BackendConnection> killees =  new HashMap<>();
+
         for (Map.Entry<RouteResultsetNode, BackendConnection> entry : target.entrySet()) {
             BackendConnection c = entry.getValue();
-            if (c != null) {
-                if (!hooked) {
-                    hooked = true;
-                    killees = new HashMap<>();
-                    count = new AtomicInteger(0);
-                }
+            if (c != null && !c.isDDL()) {
                 killees.put(entry.getKey(), c);
                 count.incrementAndGet();
+            }else if(c != null && c.isDDL()){
+                //if the sql executing is a ddl,do not kill the query,just close the connection
+                this.terminate();
+                return;
             }
         }
-        if (hooked) {
-            for (Entry<RouteResultsetNode, BackendConnection> en : killees.entrySet()) {
-                KillConnectionHandler kill = new KillConnectionHandler(
-                        en.getValue(), this);
-                ServerConfig conf = DbleServer.getInstance().getConfig();
-                PhysicalDBNode dn = conf.getDataNodes().get(
-                        en.getKey().getName());
-                try {
-                    dn.getConnectionFromSameSource(null, true, en.getValue(),
-                            kill, en.getKey());
-                } catch (Exception e) {
-                    LOGGER.error(
-                            "get killer connection failed for " + en.getKey(),
-                            e);
-                    kill.connectionError(e, null);
-                }
+
+        for (Entry<RouteResultsetNode, BackendConnection> en : killees.entrySet()) {
+            KillConnectionHandler kill = new KillConnectionHandler(
+                    en.getValue(), this);
+            ServerConfig conf = DbleServer.getInstance().getConfig();
+            PhysicalDBNode dn = conf.getDataNodes().get(
+                    en.getKey().getName());
+            try {
+                dn.getConnectionFromSameSource(en.getValue().getSchema(), true, en.getValue(),
+                        kill, en.getKey());
+            } catch (Exception e) {
+                LOGGER.error(
+                        "get killer connection failed for " + en.getKey(),
+                        e);
+                kill.connectionError(e, null);
             }
         }
     }

--- a/src/main/java/com/actiontech/dble/server/ServerConnection.java
+++ b/src/main/java/com/actiontech/dble/server/ServerConnection.java
@@ -377,6 +377,23 @@ public class ServerConnection extends FrontendConnection {
         }
     }
 
+
+
+
+    @Override
+    public void killAndClose(String reason){
+
+       if (session.getSource().isTxstart() && !session.cancelableStatusSet(NonBlockingSession.CANCEL_STATUS_CANCELING) &&
+                  session.getXaState() != null && session.getXaState() != TxState.TX_INITIALIZE_STATE) {
+            //XA transaction in this phase(commit/rollback) close the front end and wait for the backend finished
+            super.close(reason);
+        } else {
+            //not a xa transaction ,close it
+            super.close(reason);
+            session.kill();
+        }
+    }
+
     @Override
     public String toString() {
         return "ServerConnection [id=" + id + ", schema=" + schema + ", host=" + host +


### PR DESCRIPTION
Reason:
  the kill @@connection only cut off the frontend connection & the backend query is still running,when slow query occurred there has no effective order to stop the backend query
Type:
  Improvement
Influences：
  Send kill processlist_id to backend connection when the manager port send  the kill command to dble(record can be find in general log)   
        Ddl query wouldn't be killed by kill @@connection   
        Connection with a XA transaction can not be canceled wouldn't be killed 
     