### PR TITLE
 #276 Kill @@connection send kill command to backend connection

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/response/KillConnection.java
+++ b/src/main/java/com/actiontech/dble/manager/response/KillConnection.java
@@ -8,7 +8,6 @@ package com.actiontech.dble.manager.response;
 import com.actiontech.dble.DbleServer;
 import com.actiontech.dble.manager.ManagerConnection;
 import com.actiontech.dble.net.FrontendConnection;
-import com.actiontech.dble.net.NIOConnection;
 import com.actiontech.dble.net.NIOProcessor;
 import com.actiontech.dble.net.mysql.OkPacket;
 import com.actiontech.dble.util.SplitUtil;
@@ -31,10 +30,10 @@ public final class KillConnection {
         int count = 0;
         List<FrontendConnection> list = getList(stmt, offset, mc);
         if (list != null) {
-            for (NIOConnection c : list) {
+            for (FrontendConnection c : list) {
                 StringBuilder s = new StringBuilder();
                 LOGGER.warn(s.append(c).append("killed by manager").toString());
-                c.close("kill by manager");
+                c.killAndClose("kill by manager");
                 count++;
             }
         }

--- a/src/main/java/com/actiontech/dble/net/FrontendConnection.java
+++ b/src/main/java/com/actiontech/dble/net/FrontendConnection.java
@@ -508,4 +508,8 @@ public abstract class FrontendConnection extends AbstractConnection {
     public void close(String reason) {
         super.close(isAuthenticated ? reason : "");
     }
+
+    public void killAndClose(String reaseon) {
+
+    }
 }

--- a/src/main/java/com/actiontech/dble/server/ServerConnection.java
+++ b/src/main/java/com/actiontech/dble/server/ServerConnection.java
@@ -377,6 +377,22 @@ public class ServerConnection extends FrontendConnection {
         }
     }
 
+
+
+
+    @Override
+    public void killAndClose(String reason) {
+        if (session.getSource().isTxstart() && !session.cancelableStatusSet(NonBlockingSession.CANCEL_STATUS_CANCELING) &&
+                  session.getXaState() != null && session.getXaState() != TxState.TX_INITIALIZE_STATE) {
+            //XA transaction in this phase(commit/rollback) close the front end and wait for the backend finished
+            super.close(reason);
+        } else {
+            //not a xa transaction ,close it
+            super.close(reason);
+            session.kill();
+        }
+    }
+
     @Override
     public String toString() {
         return "ServerConnection [id=" + id + ", schema=" + schema + ", host=" + host +

--- a/src/main/java/com/actiontech/dble/server/handler/KillHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/KillHandler.java
@@ -50,7 +50,11 @@ public final class KillHandler {
                 }
             }
             if (fc != null) {
-                fc.close("killed");
+                if (!fc.getUser().equals(c.getUser())) {
+                    c.writeErrMessage(ErrorCode.ER_NO_SUCH_THREAD, "can't kill other user's connection" + id);
+                    return;
+                }
+                fc.killAndClose("killed");
                 getOkPacket().write(c);
             } else {
                 c.writeErrMessage(ErrorCode.ER_NO_SUCH_THREAD, "Unknown connection id:" + id);


### PR DESCRIPTION
Reason:
  the 'kill @@connection' only cut off the frontend connection & the backend query is still running,when slow query occurred there has no effective order to stop the backend query
Type:
  Improvement
Influences：
  Send kill processlist_id to backend connection when the manager port send the kill command to dble(record can be find in general log)
  Ddl query wouldn't be killed by 'kill @@connection'
  Connection with a XA transaction can not be canceled wouldn't be killed