### PR TITLE
#276 kill connection about managerConnection

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/ManagerConnection.java
+++ b/src/main/java/com/actiontech/dble/manager/ManagerConnection.java
@@ -36,4 +36,8 @@ public class ManagerConnection extends FrontendConnection {
         handler.handle(data);
     }
 
+    @Override
+    public void killAndClose(String reason) {
+        this.close(reason);
+    }
 }

--- a/src/main/java/com/actiontech/dble/net/FrontendConnection.java
+++ b/src/main/java/com/actiontech/dble/net/FrontendConnection.java
@@ -511,7 +511,5 @@ public abstract class FrontendConnection extends AbstractConnection {
         super.close(isAuthenticated ? reason : "");
     }
 
-    public void killAndClose(String reason) {
-
-    }
+    public abstract void killAndClose(String reason);
 }


### PR DESCRIPTION
Reason:
  the manager connection should also be closeable 
Type:
  Improvement
Influences：
  kill @@ connection can kill the manager connection