### PR TITLE
#289 fix the error handling when xa transaction error in prepare

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/AbstractCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/AbstractCommitNodesHandler.java
@@ -61,8 +61,8 @@ public abstract class AbstractCommitNodesHandler extends MultiNodeHandler implem
                 }
             }
         } finally {
+            lockForErrorHandle.lock();
             try {
-                lockForErrorHandle.lock();
                 sendFinishedFlag = true;
                 sendFinished.signalAll();
             } finally {

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/AbstractCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/AbstractCommitNodesHandler.java
@@ -65,7 +65,7 @@ public abstract class AbstractCommitNodesHandler extends MultiNodeHandler implem
                 lockForErrorHandle.lock();
                 sendFinishedFlag = true;
                 sendFinished.signalAll();
-            }finally {
+            } finally {
                 lockForErrorHandle.unlock();
             }
         }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -81,12 +81,14 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
             }
             commitPhase(mysqlCon);
         } else if (state == TxState.TX_PREPARE_UNCONNECT_STATE) {
+            final String errorMsg = this.error;
             if (decrementCountBy(1)) {
                 DbleServer.getInstance().getBusinessExecutor().execute(new Runnable() {
                     @Override
                     public void run() {
                         ErrorPacket error = new ErrorPacket();
                         error.setErrNo(ER_ERROR_DURING_COMMIT);
+                        error.setMessage(errorMsg.getBytes());
                         XAAutoRollbackNodesHandler nextHandler = new XAAutoRollbackNodesHandler(session, error.toBytes(), null, null);
                         nextHandler.rollback();
                     }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -82,17 +82,15 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
             commitPhase(mysqlCon);
         } else if (state == TxState.TX_PREPARE_UNCONNECT_STATE) {
             if (decrementCountBy(1)) {
-                Thread theard = new Thread(new Runnable() {
+                DbleServer.getInstance().getBusinessExecutor().execute(new Runnable() {
                     @Override
                     public void run() {
                         ErrorPacket error = new ErrorPacket();
-                        error.setMessage("BACKEND PREPARE UNCONNECTED XA TRANSTION ROLLBACKED".getBytes());
                         error.setErrNo(ER_ERROR_DURING_COMMIT);
                         XAAutoRollbackNodesHandler nextHandler = new XAAutoRollbackNodesHandler(session, error.toBytes(), null, null);
                         nextHandler.rollback();
                     }
                 });
-                theard.start();
             }
         }
         return true;
@@ -252,13 +250,12 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
     @Override
     public void connectionClose(final BackendConnection conn, final String reason) {
         final XACommitNodesHandler thisHandler = this;
-        Thread newThreadFor = new Thread(new Runnable() {
+        DbleServer.getInstance().getBusinessExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 thisHandler.connectionCloseLocal(conn, reason);
             }
         });
-        newThreadFor.start();
     }
 
 


### PR DESCRIPTION
Reason:
  `prepare` one of the nodes on sharding table failed,xa transaction hangs
Type:  
  Bug fix
Influences：  
  Add lock when send the xa command 
  If the connection is closed when the 'prepare' command is sending ,rollback this xa transaction 