### PR TITLE
#292 do not check the plugin if the authPacket use the default one

### DIFF
--- a/src/main/java/com/actiontech/dble/net/handler/FrontendAuthenticator.java
+++ b/src/main/java/com/actiontech/dble/net/handler/FrontendAuthenticator.java
@@ -60,7 +60,7 @@ public class FrontendAuthenticator implements NIOHandler {
         auth.read(data);
 
         //check mysql_native_password
-        if (!"mysql_native_password".equals(auth.getAuthPlugin())) {
+        if (auth.getAuthPlugin() != null && !"mysql_native_password".equals(auth.getAuthPlugin())) {
             failure(ErrorCode.ER_ACCESS_DENIED_ERROR, "only mysql_native_password auth check is supported");
             return;
         }


### PR DESCRIPTION
Reason:
   The strict plugin type check would cause some mysql connecter can't connect correctly
Type:
   Bug fix
Influences:
   Would not check the plugin when the authPacket did not specify the plugin type