### PR TITLE
Issue 289

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/AbstractCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/AbstractCommitNodesHandler.java
@@ -105,6 +105,11 @@ public abstract class AbstractCommitNodesHandler extends MultiNodeHandler implem
 
     }
 
+    @Override
+    public void reset(int initCount) {
+        nodeCount = initCount;
+        packetId = 0;
+    }
 
     public void debugCommitDelay() {
 

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -88,7 +88,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
                     public void run() {
                         ErrorPacket error = new ErrorPacket();
                         error.setErrNo(ER_ERROR_DURING_COMMIT);
-                        error.setMessage(errorMsg == null ? null : errorMsg.getBytes());
+                        error.setMessage(errorMsg == null ? "unknow error".getBytes() : errorMsg.getBytes());
                         XAAutoRollbackNodesHandler nextHandler = new XAAutoRollbackNodesHandler(session, error.toBytes(), null, null);
                         nextHandler.rollback();
                     }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -88,7 +88,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
                     public void run() {
                         ErrorPacket error = new ErrorPacket();
                         error.setErrNo(ER_ERROR_DURING_COMMIT);
-                        error.setMessage(errorMsg.getBytes());
+                        error.setMessage(errorMsg == null ? null : errorMsg.getBytes());
                         XAAutoRollbackNodesHandler nextHandler = new XAAutoRollbackNodesHandler(session, error.toBytes(), null, null);
                         nextHandler.rollback();
                     }


### PR DESCRIPTION
Reason:
  prepare one of the nodes on sharding table failed,xa transaction hangs
Type:
  Bug fix
Influences：
  Override the reset function in class AbstractCommitNodesHandler
  Add nullPorint Error check when use the errorMsg