### PR TITLE
Issue-289 fix the error handling when xa transaction error in prepare

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
@@ -34,9 +34,7 @@ public class NewConnectionRespHandler implements ResponseHandler {
             return backConn;
         } catch (InterruptedException e) {
             LOGGER.warn("getBackConn " + e);
-            return null;
-        } catch (IOException e) {
-            throw e;
+            throw new IOException(e.getMessage());
         } finally {
             lock.unlock();
         }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
@@ -24,7 +24,7 @@ public class NewConnectionRespHandler implements ResponseHandler {
     public BackendConnection getBackConn() {
         lock.lock();
         try {
-            while (backConn == null) {
+            if (backConn == null) {
                 initiated.await();
             }
             return backConn;
@@ -39,7 +39,12 @@ public class NewConnectionRespHandler implements ResponseHandler {
     @Override
     public void connectionError(Throwable e, BackendConnection conn) {
         LOGGER.warn(conn + " connectionError " + e);
-
+        lock.lock();
+        try {
+            initiated.signal();
+        }finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
@@ -11,6 +11,7 @@ import com.actiontech.dble.net.mysql.RowDataPacket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -21,16 +22,21 @@ public class NewConnectionRespHandler implements ResponseHandler {
     private ReentrantLock lock = new ReentrantLock();
     private Condition initiated = lock.newCondition();
 
-    public BackendConnection getBackConn() {
+    public BackendConnection getBackConn() throws IOException{
         lock.lock();
         try {
             if (backConn == null) {
                 initiated.await();
             }
+            if(backConn == null){
+                throw new IOException("get backend connection error ");
+            }
             return backConn;
         } catch (InterruptedException e) {
             LOGGER.warn("getBackConn " + e);
             return null;
+        } catch(IOException e){
+            throw  e;
         } finally {
             lock.unlock();
         }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
@@ -22,21 +22,21 @@ public class NewConnectionRespHandler implements ResponseHandler {
     private ReentrantLock lock = new ReentrantLock();
     private Condition initiated = lock.newCondition();
 
-    public BackendConnection getBackConn() throws IOException{
+    public BackendConnection getBackConn() throws IOException {
         lock.lock();
         try {
             if (backConn == null) {
                 initiated.await();
             }
-            if(backConn == null){
+            if (backConn == null) {
                 throw new IOException("get backend connection error ");
             }
             return backConn;
         } catch (InterruptedException e) {
             LOGGER.warn("getBackConn " + e);
             return null;
-        } catch(IOException e){
-            throw  e;
+        } catch (IOException e) {
+            throw e;
         } finally {
             lock.unlock();
         }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/NewConnectionRespHandler.java
@@ -42,7 +42,7 @@ public class NewConnectionRespHandler implements ResponseHandler {
         lock.lock();
         try {
             initiated.signal();
-        }finally {
+        } finally {
             lock.unlock();
         }
     }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
@@ -341,7 +341,8 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
             session.getSource().write(send);
 
             //partitionly commited,must commit again
-        } else if (session.getXaState() == TxState.TX_ROLLBACK_FAILED_STATE || session.getXaState() == TxState.TX_PREPARED_STATE) {
+        } else if (session.getXaState() == TxState.TX_ROLLBACK_FAILED_STATE || session.getXaState() == TxState.TX_PREPARED_STATE
+                || session.getXaState() == TxState.TX_PREPARE_UNCONNECT_STATE) {
             MySQLConnection errConn = session.releaseExcept(session.getXaState());
             if (errConn != null) {
                 XAStateLog.saveXARecoveryLog(session.getSessionXaID(), session.getXaState());

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
@@ -341,8 +341,8 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
             session.getSource().write(send);
 
             //partitionly commited,must commit again
-        } else if (session.getXaState() == TxState.TX_ROLLBACK_FAILED_STATE || session.getXaState() == TxState.TX_PREPARED_STATE
-                || session.getXaState() == TxState.TX_PREPARE_UNCONNECT_STATE) {
+        } else if (session.getXaState() == TxState.TX_ROLLBACK_FAILED_STATE || session.getXaState() == TxState.TX_PREPARED_STATE ||
+                session.getXaState() == TxState.TX_PREPARE_UNCONNECT_STATE) {
             MySQLConnection errConn = session.releaseExcept(session.getXaState());
             if (errConn != null) {
                 XAStateLog.saveXARecoveryLog(session.getSessionXaID(), session.getXaState());


### PR DESCRIPTION
Reason:
  When prepare failed ，rollbackHandler try to get a new connection of mysql,and will wait until the connection acquired.That whould cause the rollbackHandler hanging when the mysql server is crashed down
Type:
  Bug fix
Influences：
  Change the behavior of get a new connection 
  If not rollback successfully,try to rollback for several times