### PR TITLE
fix repeat quotes

### DIFF
--- a/src/main/java/com/actiontech/dble/config/Versions.java
+++ b/src/main/java/com/actiontech/dble/config/Versions.java
@@ -12,7 +12,7 @@ public abstract class Versions {
 
     public static final byte PROTOCOL_VERSION = 10;
 
-    private static byte[] serverVersion = "5.6.29-dble-2.17.09.0-dev-20171101134337".getBytes();
+    private static byte[] serverVersion = "5.6.29-dble-2.17.09.0-dev-20171103130933".getBytes();
     public static final byte[] VERSION_COMMENT = "dble Server (ActionTech)".getBytes();
     public static final String ANNOTATION_NAME = "dble:";
     public static final String ROOT_PREFIX = "dble";

--- a/src/main/java/com/actiontech/dble/server/ServerSptPrepare.java
+++ b/src/main/java/com/actiontech/dble/server/ServerSptPrepare.java
@@ -56,10 +56,34 @@ public final class ServerSptPrepare {
         sptStmt = stmt;
     }
 
+    /* In user variable, the string is primordial, so we have to truncate the quotes */
+    private String getStmtFromUserVar() {
+        String key = "@" + sptStmt;
+        String stmt = source.getUsrVariables().get(key);
+        String rstmt = null;
+
+        if (stmt != null) {
+            for (int i = 0; i < stmt.length(); i++) {
+                char c1 = stmt.charAt(i);
+                switch (c1) {
+                    case '\'':
+                    case '"':
+                        int j = stmt.lastIndexOf(c1, stmt.length() - 1);
+                        if (j != -1) {
+                            rstmt = stmt.substring(++i, j);
+                        }
+                        return rstmt;
+                    default:
+                        break;
+                }
+            }
+        }
+        return rstmt;
+    }
+
     public String getExePrepare() {
         if (isUserVar) {
-            String key = "@" + sptStmt;
-            return source.getUsrVariables().get(key);
+            return getStmtFromUserVar();
         } else {
             return sptStmt;
         }

--- a/src/test/java/com/actiontech/dble/parser/ServerParseTest.java
+++ b/src/test/java/com/actiontech/dble/parser/ServerParseTest.java
@@ -33,6 +33,8 @@ public class ServerParseTest {
      * public static final int MYSQL_COMMENT = 19;
      * public static final int CALL = 20;
      * public static final int DESCRIBE = 21;
+     *
+     * public static final int SCRIPT_PREPARE = 101;
      */
 
     @Test
@@ -60,6 +62,22 @@ public class ServerParseTest {
     }
 
     @Test
+    public void testDroprepare() {
+        String sql = "drop prepare stmt";
+        int result = ServerParse.parse(sql);
+        int sqlType = result & 0xff;
+        Assert.assertEquals(ServerParse.SCRIPT_PREPARE, sqlType);
+    }
+
+    @Test
+    public void testDeallocate() {
+        String sql = "Deallocate prepare stmt";
+        int result = ServerParse.parse(sql);
+        int sqlType = result & 0xff;
+        Assert.assertEquals(ServerParse.SCRIPT_PREPARE, sqlType);
+    }
+
+    @Test
     public void testInsert() {
         String sql = "insert into a(name) values ('zhangsan')";
         int result = ServerParse.parse(sql);
@@ -73,6 +91,14 @@ public class ServerParseTest {
         int result = ServerParse.parse(sql);
         int sqlType = result & 0xff;
         Assert.assertEquals(ServerParse.REPLACE, sqlType);
+    }
+
+    @Test
+    public void testPrepare() {
+        String sql = "prepare stmt from 'select * from aa where id=?'";
+        int result = ServerParse.parse(sql);
+        int sqlType = result & 0xff;
+        Assert.assertEquals(ServerParse.SCRIPT_PREPARE, sqlType);
     }
 
     @Test
@@ -137,6 +163,14 @@ public class ServerParseTest {
         int result = ServerParse.parse(sql);
         int sqlType = result & 0xff;
         Assert.assertEquals(ServerParse.EXPLAIN, sqlType);
+    }
+
+    @Test
+    public void testExecute() {
+        String sql = "execute stmt using @f1, f2";
+        int result = ServerParse.parse(sql);
+        int sqlType = result & 0xff;
+        Assert.assertEquals(ServerParse.SCRIPT_PREPARE, sqlType);
     }
 
     @Test

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
-BuildTime  2017-11-01 05:43:36
+BuildTime  2017-11-03 05:09:32
 MavenVersion 2.17.09.0-dev
 GitUrl https://github.com/actiontech/dble
 WebSite http://dble.cloud/


### PR DESCRIPTION
Reason:
when prepare statement is from user variable, eg. prepare stmt from @stmt1, we get two level quote in the
constructed statement, because @stmt1 is primordial.
Type:  
fix
Influences：  
prepare