### PR TITLE
fix, don't make up script execute statement

### DIFF
--- a/src/main/java/com/actiontech/dble/server/response/SptExecute.java
+++ b/src/main/java/com/actiontech/dble/server/response/SptExecute.java
@@ -39,15 +39,16 @@ public final class SptExecute {
             return;
         }
 
-        String stmt = parts.get(0);
+        StringBuilder stmt = new StringBuilder(parts.get(0));
         for (int i = 1; i < parts.size() ; i++) {
             String val = queryUserVar(args.get(i - 1), c);
             if (val == null) {
                 c.writeErrMessage(ErrorCode.ER_PARSE_ERROR, "Incorrect arguments to EXECUTE");
                 return;
             }
-            stmt = stmt + val;
+            stmt.append(val);
+            stmt.append(parts.get(i));
         }
-        c.query(stmt);
+        c.query(stmt.toString());
     }
 }


### PR DESCRIPTION
Reason:
don't make up script execute statement when statement contain multi variables
Type: 
 fix
Influences：  
execute statment in script
