### PR TITLE
#326 Transaction consistency does not keep on once dble restarts or c…

### DIFF
--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -947,6 +947,13 @@ public final class DbleServer {
                             SQLJob sqlJob = new SQLJob(xaCmd.toString(), dn.getDatabase(), resultHandler, dn.getDbPool().getSource());
                             sqlJob.run();
                             LOGGER.debug(String.format("[%s] Host:[%s] schema:[%s]", xaCmd, dn.getName(), dn.getDatabase()));
+
+                            //reset xaCmd
+                            if (needCommit) {
+                                xaCmd = new StringBuilder("XA COMMIT ");
+                            } else {
+                                xaCmd = new StringBuilder("XA ROLLBACK ");
+                            }
                             break outLoop;
                         }
                     }

--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -949,10 +949,11 @@ public final class DbleServer {
                             LOGGER.debug(String.format("[%s] Host:[%s] schema:[%s]", xaCmd, dn.getName(), dn.getDatabase()));
 
                             //reset xaCmd
+                            xaCmd.setLength(0);
                             if (needCommit) {
-                                xaCmd = new StringBuilder("XA COMMIT ");
+                                xaCmd.append("XA COMMIT ");
                             } else {
-                                xaCmd = new StringBuilder("XA ROLLBACK ");
+                                xaCmd.append("XA ROLLBACK ");
                             }
                             break outLoop;
                         }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
@@ -100,6 +100,9 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
             if (mysqlCon.isClosed()) {
                 mysqlCon.setXaStatus(TxState.TX_CONN_QUIT);
             }
+            if (position == 0) {
+                this.debugRollbackDelay();
+            }
             rollbackPhase(mysqlCon);
         }
         return true;


### PR DESCRIPTION
Reason: 
  Fix issue #326 
  Fix ROLLBACK_DELAY
Type:  
  Fix
Influences：  
  Rest StringBuffer after one XA recovery query sent
  Add ROLLBACK_DELAY trigger into right place
