### PR TITLE
fix incorrect key being ignored

### DIFF
--- a/src/main/java/com/actiontech/dble/config/Versions.java
+++ b/src/main/java/com/actiontech/dble/config/Versions.java
@@ -12,7 +12,7 @@ public abstract class Versions {
 
     public static final byte PROTOCOL_VERSION = 10;
 
-    private static byte[] serverVersion = "5.6.29-dble-2.17.09.0-dev-20171103130933".getBytes();
+    private static byte[] serverVersion = "5.6.29-dble-2.17.11.0-dev-20171129140053".getBytes();
     public static final byte[] VERSION_COMMENT = "dble Server (ActionTech)".getBytes();
     public static final String ANNOTATION_NAME = "dble:";
     public static final String ROOT_PREFIX = "dble";

--- a/src/main/java/com/actiontech/dble/server/parser/ServerParse.java
+++ b/src/main/java/com/actiontech/dble/server/parser/ServerParse.java
@@ -59,7 +59,7 @@ public final class ServerParse {
     public static int parse(String stmt) {
         int length = stmt.length();
         //FIX BUG FOR SQL SUCH AS /XXXX/SQL
-        int rt = -1;
+        int rt = OTHER;
         for (int i = 0; i < length; ++i) {
             switch (stmt.charAt(i)) {
                 case ' ':
@@ -144,12 +144,9 @@ public final class ServerParse {
                 default:
                     break;
             }
-            if (rt != OTHER) {
-                return rt;
-            }
-            continue;
+            break;
         }
-        return OTHER;
+        return rt;
     }
 
     private static int eCheck(String stmt, int offset) {

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
-BuildTime  2017-11-03 05:09:32
+BuildTime  2017-11-29 06:00:52
 MavenVersion 2.17.11.0-dev
 GitUrl https://github.com/actiontech/dble
 WebSite http://dble.cloud/


### PR DESCRIPTION
Reason: 
when the first key is incorrect， the parser skips it and continues parseing. 
eg. 
shsh create table xxx(a int, b char(32))；

when the statement was parse, the shsk will be skiped, the actual result is executing：

create table xxx(a int, b char(32))；

This is wrong. The bug was brought in from the commit ff7f9160acff462fdc02bae9e6f2cf99c5fb1dc0 in mycat. But I don't find the reason and a statement that should be parsed by the way. Maybe the writer only get to the root of the matter. I just fix it.

Type:  fix

Influences：  
all statement.