### PR TITLE
 #345 Error when `view` contains a statement which like`select table1…

### DIFF
--- a/src/main/java/com/actiontech/dble/meta/ViewMeta.java
+++ b/src/main/java/com/actiontech/dble/meta/ViewMeta.java
@@ -155,10 +155,17 @@ public class ViewMeta {
             List<Item> selectList = selNode.getColumnsSelected();
             Set<String> tempMap = new HashSet<String>();
             for (Item t : selectList) {
-                if (tempMap.contains(t.getItemName())) {
-                    throw new Exception("Duplicate column name '" + t.getItemName() + "'");
+                if (t.getAlias() != null) {
+                    if (tempMap.contains(t.getAlias())) {
+                        throw new Exception("Duplicate column name '" + t.getItemName() + "'");
+                    }
+                    tempMap.add(t.getAlias());
+                } else {
+                    if (tempMap.contains(t.getItemName())) {
+                        throw new Exception("Duplicate column name '" + t.getItemName() + "'");
+                    }
+                    tempMap.add(t.getItemName());
                 }
-                tempMap.add(t.getItemName());
             }
         }
     }


### PR DESCRIPTION
Reason:
  Fixes #345
Type:
  Fixes
Influences：
  Change the check of 'Duplicate column'