### PR TITLE
fix, must restart if not setting

### DIFF
--- a/src/main/java/com/actiontech/dble/route/sequence/handler/IncrSequenceMySQLHandler.java
+++ b/src/main/java/com/actiontech/dble/route/sequence/handler/IncrSequenceMySQLHandler.java
@@ -103,6 +103,7 @@ public class IncrSequenceMySQLHandler implements SequenceHandler {
             throw new RuntimeException("can't fetch sequence in db,sequence :" + seqVal.seqName + " detail:" +
                                        mysqlSeqFetcher.getLastestError(seqVal.seqName));
         } else if (values[0] == 0) {
+            seqVal.fetching.compareAndSet(true, false);
             String msg = "sequence," + seqVal.seqName + "has not been set, please check configure in dble_sequence";
             LOGGER.warn(msg);
             throw new SQLNonTransientException(msg);


### PR DESCRIPTION
Reason:
dble must restart if db sequence don't been set.
Type:  bug
Influences：  
global sequence in db mode