### PR TITLE
#387, jvm version incompatibility about HashMap.replace

### DIFF
--- a/src/main/java/com/actiontech/dble/server/ServerSptPrepare.java
+++ b/src/main/java/com/actiontech/dble/server/ServerSptPrepare.java
@@ -27,11 +27,7 @@ public final class ServerSptPrepare {
     }
 
     public void setPrepare(String name0, List<String> parts) {
-        if (sptPrepares.containsKey(name0)) {
-            sptPrepares.replace(name0, parts);
-        } else {
-            sptPrepares.put(name0, parts);
-        }
+        sptPrepares.put(name0, parts);
     }
 
     public List<String> getPrepare(String name0) {


### PR DESCRIPTION
Reason:
the method HashMap.replace  is a new methon in java 1.8. So useing jre 1.7 will throw a runtime exception that don't be catch. 
Type:  bug
Influences：  
script prepare statement