### PR TITLE
#363 fix and show create view support

### DIFF
--- a/src/main/java/com/actiontech/dble/meta/ViewMeta.java
+++ b/src/main/java/com/actiontech/dble/meta/ViewMeta.java
@@ -223,6 +223,19 @@ public class ViewMeta {
         return viewColumnMeta;
     }
 
+    public String getViewColumnMetaString() {
+        if (viewColumnMeta != null) {
+            StringBuffer sb = new StringBuffer("(");
+            for (String s : viewColumnMeta) {
+                sb.append(s);
+                sb.append(",");
+            }
+            sb.setCharAt(sb.length() - 1, ')');
+            return sb.toString();
+        }
+        return null;
+    }
+
     public void setViewColumnMeta(List<String> viewColumnMeta) {
         this.viewColumnMeta = viewColumnMeta;
     }

--- a/src/main/java/com/actiontech/dble/meta/ViewMeta.java
+++ b/src/main/java/com/actiontech/dble/meta/ViewMeta.java
@@ -31,12 +31,9 @@ public class ViewMeta {
 
     public ErrorPacket init(boolean isReplace) {
 
-        //check the create sql is legal
-        //parse sql into three parts
         ViewMetaParser viewParser = new ViewMetaParser(createSql);
-        viewParser.parseCreateView(this);
-
         try {
+            viewParser.parseCreateView(this);
             //check if the select part has
             this.checkDuplicate(viewParser, isReplace);
 

--- a/src/main/java/com/actiontech/dble/meta/ViewMetaParser.java
+++ b/src/main/java/com/actiontech/dble/meta/ViewMetaParser.java
@@ -108,6 +108,8 @@ public class ViewMetaParser {
                             originalSql.charAt(offset) == 'S')) {
                 offset++;
                 break;
+            }else if(offset == originalSql.length()-1){
+                throw new RuntimeException("You have an error in your SQL syntax;");
             }
 
         }

--- a/src/main/java/com/actiontech/dble/meta/ViewMetaParser.java
+++ b/src/main/java/com/actiontech/dble/meta/ViewMetaParser.java
@@ -108,7 +108,7 @@ public class ViewMetaParser {
                             originalSql.charAt(offset) == 'S')) {
                 offset++;
                 break;
-            }else if(offset == originalSql.length()-1){
+            } else if (offset == originalSql.length() - 1) {
                 throw new RuntimeException("You have an error in your SQL syntax;");
             }
 

--- a/src/main/java/com/actiontech/dble/server/handler/ShowHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ShowHandler.java
@@ -44,12 +44,12 @@ public final class ShowHandler {
             case ServerParseShow.VARIABLES:
                 ShowVariables.response(c, stmt);
                 break;
-            case ServerParseShow.CHARSET:
-                stmt = stmt.toLowerCase().replaceFirst("charset", "character set");
-                // fallthrough
             case ServerParseShow.CREATE_VIEW:
                 ShowCreateView.response(c, stmt);
                 break;
+            case ServerParseShow.CHARSET:
+                stmt = stmt.toLowerCase().replaceFirst("charset", "character set");
+                // fallthrough
             default:
                 c.execute(stmt, ServerParse.SHOW);
         }

--- a/src/main/java/com/actiontech/dble/server/handler/ShowHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ShowHandler.java
@@ -47,6 +47,9 @@ public final class ShowHandler {
             case ServerParseShow.CHARSET:
                 stmt = stmt.toLowerCase().replaceFirst("charset", "character set");
                 // fallthrough
+            case ServerParseShow.CREATE_VIEW:
+                ShowCreateView.response(c, stmt);
+                break;
             default:
                 c.execute(stmt, ServerParse.SHOW);
         }

--- a/src/main/java/com/actiontech/dble/server/parser/ServerParseShow.java
+++ b/src/main/java/com/actiontech/dble/server/parser/ServerParseShow.java
@@ -158,7 +158,7 @@ public final class ServerParseShow {
             char c4 = stmt.charAt(++offset);
             char c5 = stmt.charAt(++offset);
             if ((c1 == 'L' || c1 == 'l') && (c2 == 'O' || c2 == 'o') && (c3 == 'B' || c3 == 'b') && (c4 == 'A' || c4 == 'a') &&
-                (c5 == 'L' || c5 == 'l')) {
+                    (c5 == 'L' || c5 == 'l')) {
                 while (stmt.length() > ++offset) {
                     if (ParseUtil.isSpace(stmt.charAt(offset))) {
                         continue;
@@ -206,10 +206,10 @@ public final class ServerParseShow {
                             char c9 = stmt.charAt(++offset);
                             char c10 = stmt.charAt(++offset);
                             char c11 = stmt.charAt(++offset);
-                            if((c9 == 'i' || c9 == 'I') &&
+                            if ((c9 == 'i' || c9 == 'I') &&
                                     (c10 == 'e' || c10 == 'E') &&
                                     (c11 == 'w' || c11 == 'W') &&
-                                    (ParseUtil.isSpace(stmt.charAt(++offset)))){
+                                    (ParseUtil.isSpace(stmt.charAt(++offset)))) {
                                 return CREATE_VIEW;
                             }
                             return OTHER;
@@ -265,7 +265,7 @@ public final class ServerParseShow {
         char c4 = stmt.charAt(++offset);
         char c5 = stmt.charAt(++offset);
         if ((c1 == 'H' || c1 == 'h') && (c2 == 'E' || c2 == 'e') && (c3 == 'M' || c3 == 'm') && (c4 == 'A' || c4 == 'a') && (c5 == 'S' || c5 == 's') &&
-            (stmt.length() == ++offset || ParseUtil.isEOF(stmt, offset))) {
+                (stmt.length() == ++offset || ParseUtil.isEOF(stmt, offset))) {
             return DATABASES;
         }
         return OTHER;
@@ -351,8 +351,8 @@ public final class ServerParseShow {
             char c8 = stmt.charAt(++offset);
             char c9 = stmt.charAt(++offset);
             if ((c1 == 'V' || c1 == 'v') && (c2 == 'A' || c2 == 'a') && (c3 == 'R' || c3 == 'r') && (c4 == 'I' || c4 == 'i') &&
-                (c5 == 'A' || c5 == 'a') && (c6 == 'B' || c6 == 'b') && (c7 == 'L' || c7 == 'l') && (c8 == 'E' || c8 == 'e') &&
-                (c9 == 'S' || c9 == 's')) {
+                    (c5 == 'A' || c5 == 'a') && (c6 == 'B' || c6 == 'b') && (c7 == 'L' || c7 == 'l') && (c8 == 'E' || c8 == 'e') &&
+                    (c9 == 'S' || c9 == 's')) {
                 return VARIABLES;
             }
         }

--- a/src/main/java/com/actiontech/dble/server/parser/ServerParseShow.java
+++ b/src/main/java/com/actiontech/dble/server/parser/ServerParseShow.java
@@ -28,6 +28,7 @@ public final class ServerParseShow {
     public static final int INDEX = 9;
     public static final int CREATE_TABLE = 10;
     public static final int VARIABLES = 11;
+    public static final int CREATE_VIEW = 12;
 
     public static int parse(String stmt, int offset) {
         int i = offset;
@@ -198,6 +199,18 @@ public final class ServerParseShow {
                                     (c8 == 'E' || c8 == 'e') &&
                                     (ParseUtil.isSpace(stmt.charAt(++offset)))) {
                                 return CREATE_TABLE;
+                            }
+                            return OTHER;
+                        case 'V':
+                        case 'v':
+                            char c9 = stmt.charAt(++offset);
+                            char c10 = stmt.charAt(++offset);
+                            char c11 = stmt.charAt(++offset);
+                            if((c9 == 'i' || c9 == 'I') &&
+                                    (c10 == 'e' || c10 == 'E') &&
+                                    (c11 == 'w' || c11 == 'W') &&
+                                    (ParseUtil.isSpace(stmt.charAt(++offset)))){
+                                return CREATE_VIEW;
                             }
                             return OTHER;
                         default:

--- a/src/main/java/com/actiontech/dble/server/response/ShowCreateView.java
+++ b/src/main/java/com/actiontech/dble/server/response/ShowCreateView.java
@@ -1,0 +1,29 @@
+package com.actiontech.dble.server.response;
+
+import com.actiontech.dble.DbleServer;
+import com.actiontech.dble.config.ServerConfig;
+import com.actiontech.dble.config.model.UserConfig;
+import com.actiontech.dble.net.mysql.EOFPacket;
+import com.actiontech.dble.net.mysql.FieldPacket;
+import com.actiontech.dble.net.mysql.RowDataPacket;
+import com.actiontech.dble.server.ServerConnection;
+import com.actiontech.dble.util.StringUtil;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Created by szf on 2017/12/15.
+ */
+public class ShowCreateView {
+
+
+    public static void response(ServerConnection c) {
+
+
+
+
+    }
+}

--- a/src/main/java/com/actiontech/dble/server/response/ShowCreateView.java
+++ b/src/main/java/com/actiontech/dble/server/response/ShowCreateView.java
@@ -1,29 +1,124 @@
 package com.actiontech.dble.server.response;
 
 import com.actiontech.dble.DbleServer;
-import com.actiontech.dble.config.ServerConfig;
-import com.actiontech.dble.config.model.UserConfig;
+import com.actiontech.dble.backend.mysql.PacketUtil;
+import com.actiontech.dble.config.ErrorCode;
+import com.actiontech.dble.config.Fields;
+import com.actiontech.dble.meta.SchemaMeta;
+import com.actiontech.dble.meta.ViewMeta;
 import com.actiontech.dble.net.mysql.EOFPacket;
 import com.actiontech.dble.net.mysql.FieldPacket;
+import com.actiontech.dble.net.mysql.ResultSetHeaderPacket;
 import com.actiontech.dble.net.mysql.RowDataPacket;
+import com.actiontech.dble.route.factory.RouteStrategyFactory;
 import com.actiontech.dble.server.ServerConnection;
 import com.actiontech.dble.util.StringUtil;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlShowCreateViewStatement;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Created by szf on 2017/12/15.
  */
-public class ShowCreateView {
+public final class ShowCreateView {
 
 
-    public static void response(ServerConnection c) {
+    private static final int FIELD_COUNT = 4;
+    private static final ResultSetHeaderPacket HEADER = PacketUtil.getHeader(FIELD_COUNT);
+    private static final FieldPacket[] FIELDS = new FieldPacket[FIELD_COUNT];
+    private static final EOFPacket EOF = new EOFPacket();
 
+    static {
+        int i = 0;
+        byte packetId = 0;
+        HEADER.setPacketId(++packetId);
+        FIELDS[i] = PacketUtil.getField("View",
+                Fields.FIELD_TYPE_VAR_STRING);
+        FIELDS[i++].setPacketId(++packetId);
 
+        FIELDS[i] = PacketUtil.getField("Create View", Fields.FIELD_TYPE_VAR_STRING);
+        FIELDS[i++].setPacketId(++packetId);
 
+        FIELDS[i] = PacketUtil.getField("character_set_client", Fields.FIELD_TYPE_VAR_STRING);
+        FIELDS[i++].setPacketId(++packetId);
+
+        FIELDS[i] = PacketUtil.getField("collation_connection", Fields.FIELD_TYPE_VAR_STRING);
+        FIELDS[i++].setPacketId(++packetId);
+
+        EOF.setPacketId(++packetId);
+    }
+
+    private ShowCreateView() {
 
     }
+
+    public static void response(ServerConnection c, String stmt) {
+        try {
+            MySqlShowCreateViewStatement statement = (MySqlShowCreateViewStatement) RouteStrategyFactory.getRouteStrategy().parserSQL(stmt);
+            if (statement.getName() instanceof SQLPropertyExpr) {
+                //show create view with schema
+                SQLPropertyExpr sqlPropertyExpr = (SQLPropertyExpr) statement.getName();
+                //protocol not equals the nomul things
+                sendOutTheViewInfo(c, sqlPropertyExpr.getOwner().toString(), sqlPropertyExpr.getName());
+            } else if (statement.getName() instanceof SQLIdentifierExpr) {
+                sendOutTheViewInfo(c, c.getSchema(), statement.getName().toString());
+            }
+        } catch (Exception e) {
+            c.writeErrMessage(ErrorCode.ER_PARSE_ERROR, e.getMessage());
+        }
+    }
+
+    public static void sendOutTheViewInfo(ServerConnection c, String schema, String viewName) throws Exception {
+        //check if the view or schema is not exists
+        if (schema == null || "".equals(schema)) {
+            throw new Exception(" No database selected");
+        }
+
+        SchemaMeta schemaMeta = DbleServer.getInstance().getTmManager().getCatalogs().get(schema);
+        if (schemaMeta == null) {
+            throw new Exception("Table '" + schema + "." + viewName + "' doesn't exist");
+        }
+
+        ViewMeta view = schemaMeta.getViewMetas().get(viewName);
+        if (view == null) {
+            throw new Exception("Table '" + schema + "." + viewName + "' doesn't exist");
+        }
+
+        ByteBuffer buffer = c.allocate();
+        // write header
+        buffer = HEADER.write(buffer, c, true);
+        // write fields
+        for (FieldPacket field : FIELDS) {
+            buffer = field.write(buffer, c, true);
+        }
+        // write eof
+        buffer = EOF.write(buffer, c, true);
+        // write rows
+        byte packetId = EOF.getPacketId();
+        RowDataPacket row = getRow(view, c.getCharset().getResults(), c.getCharset().getCollation());
+        row.setPacketId(++packetId);
+        buffer = row.write(buffer, c, true);
+        // write last eof
+        EOFPacket lastEof = new EOFPacket();
+        lastEof.setPacketId(++packetId);
+        buffer = lastEof.write(buffer, c, true);
+        // write buffer
+        c.write(buffer);
+    }
+
+    public static RowDataPacket getRow(ViewMeta view, String charset, String collationConnection) {
+        RowDataPacket row = new RowDataPacket(FIELD_COUNT);
+        row.add(StringUtil.encode(view.getViewName(), charset));
+        if (view.getViewColumnMeta() != null && view.getViewColumnMeta().size() > 0) {
+            row.add(StringUtil.encode("create view " + view.getViewName() + view.getViewColumnMetaString() + " as " + view.getSelectSql(), charset));
+        } else {
+            row.add(StringUtil.encode("create view " + view.getViewName() + " as " + view.getSelectSql(), charset));
+        }
+        row.add(StringUtil.encode(charset, charset));
+        row.add(StringUtil.encode(collationConnection, charset));
+        return row;
+    }
+
 }


### PR DESCRIPTION
Reason:
  In `view`,The return messages of unsupported syntax and wrong syntax are not accurate
Type:  
  Improve #363   
Influences：  
  Add 'show create view' support
  Improve the error message when the create view sql is not correct


