### PR TITLE
Error when `subquery ` contains `view`

### DIFF
--- a/src/main/java/com/actiontech/dble/route/util/RouterUtil.java
+++ b/src/main/java/com/actiontech/dble/route/util/RouterUtil.java
@@ -762,7 +762,8 @@ public final class RouterUtil {
         if (schemaConfig.isNoSharding()) {
             return true;
         }
-        return schemaConfig.getDataNode() != null && !schemaConfig.getTables().containsKey(tableName);
+        return schemaConfig.getDataNode() != null && !schemaConfig.getTables().containsKey(tableName) &&
+                !DbleServer.getInstance().getTmManager().getCatalogs().get(schemaConfig.getName()).getViewMetas().containsKey(tableName);
     }
 
     /**


### PR DESCRIPTION
Reason:
  the view use in subquery would be identified as nosharding table
Type:  
  Bug #375 
Influences：  
  Add nosharding conditions whether the tableName is a viewName