### PR TITLE
#411 Dble can not startup when the schema.xml is almost empty

### DIFF
--- a/src/main/java/com/actiontech/dble/config/ConfigInitializer.java
+++ b/src/main/java/com/actiontech/dble/config/ConfigInitializer.java
@@ -41,7 +41,7 @@ public class ConfigInitializer {
     private volatile Map<ERTable, Set<ERTable>> erRelations;
 
 
-    private volatile boolean dataHostWithoutWH = false;
+    private volatile boolean dataHostWithoutWH = true;
 
     public ConfigInitializer(boolean loadDataHost, boolean lowerCaseNames) {
         //load server.xml
@@ -160,9 +160,11 @@ public class ConfigInitializer {
 
     private void checkWriteHost() {
         for (Map.Entry<String, PhysicalDBPool> pool : this.dataHosts.entrySet()) {
+            this.dataHostWithoutWH = false;
             if (pool.getValue().getSources() == null || pool.getValue().getSources().length == 0) {
                 LOGGER.info("dataHost " + pool.getKey() + " has no writeHost ,server will ignore it");
                 this.dataHostWithoutWH = true;
+                break;
             }
         }
     }


### PR DESCRIPTION
Reason:
         Bug #411
Type:  
        Bug fix 
Influences：  
        Default dataHostWithoutWH set to true,only set false when the dataHosts is not empty
