### PR TITLE
#411 Dble can not startup when the schema.xml is almost empty

### DIFF
--- a/src/main/java/com/actiontech/dble/config/ConfigInitializer.java
+++ b/src/main/java/com/actiontech/dble/config/ConfigInitializer.java
@@ -66,6 +66,8 @@ public class ConfigInitializer {
         }
 
         this.firewall = serverLoader.getFirewall();
+
+        deleteRedundancyConf();
         checkWriteHost();
     }
 


### PR DESCRIPTION
Reason:
  Bug #411
Type:
  Bug fix
Influences：
  Add function call in ConfigInitializer init