### PR TITLE
ucore online init when the config is incomplete

### DIFF
--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (C) 2016-2018 ActionTech.
-* based on code by MyCATCopyrightHolder Copyright (c) 2013, OpenCloudDB/MyCAT.
-* License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher.
-*/
+ * Copyright (C) 2016-2018 ActionTech.
+ * based on code by MyCATCopyrightHolder Copyright (c) 2013, OpenCloudDB/MyCAT.
+ * License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher.
+ */
 package com.actiontech.dble;
 
 import com.actiontech.dble.backend.BackendConnection;
@@ -411,6 +411,10 @@ public final class DbleServer {
         }
 
         pullVarAndMeta();
+
+        if (isUseUcore()) {
+            tmManager.metaUcoreinit();
+        }
         //initialized the cache service
         cacheService = new CacheService(this.systemVariables.isLowerCaseTableNames());
 

--- a/src/main/java/com/actiontech/dble/meta/ProxyMetaManager.java
+++ b/src/main/java/com/actiontech/dble/meta/ProxyMetaManager.java
@@ -275,14 +275,12 @@ public class ProxyMetaManager {
     public void init(ServerConfig config) throws Exception {
         if (DbleServer.getInstance().isUseZK()) {
             this.metaZKinit(config);
-        } else if (DbleServer.getInstance().isUseUcore()) {
-            metaUcoreinit(config);
         } else {
             initMeta(config);
         }
     }
 
-    private void metaUcoreinit(ServerConfig config) throws Exception {
+    public void metaUcoreinit() {
         //check if the online mark is on than delete the mark and renew it
         ClusterUcoreSender.deleteKV(UcorePathUtil.getOnlinePath(UcoreConfig.getInstance().
                 getValue(ClusterParamCfg.CLUSTER_CFG_MYID)));
@@ -290,7 +288,6 @@ public class ProxyMetaManager {
                 getValue(ClusterParamCfg.CLUSTER_CFG_MYID)),
                 UcoreConfig.getInstance().getValue(ClusterParamCfg.CLUSTER_CFG_MYID));
         onlineLock.acquire();
-        initMeta(config);
     }
 
 


### PR DESCRIPTION
Reason:
  Bug  when the config incomplete Cluster online miss
Type:
  Bug fix
Influences：
  Set online ever if the config is incomplete