### PR TITLE
#569 change timestamp type from long to string

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/response/ShowCache.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowCache.java
@@ -50,9 +50,9 @@ public final class ShowCache {
         FIELDS[i++].setPacketId(++packetId);
         FIELDS[i] = PacketUtil.getField("PUT", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);
-        FIELDS[i] = PacketUtil.getField("LAST_ACCESS", Fields.FIELD_TYPE_LONG);
+        FIELDS[i] = PacketUtil.getField("LAST_ACCESS", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
-        FIELDS[i] = PacketUtil.getField("LAST_PUT", Fields.FIELD_TYPE_LONG);
+        FIELDS[i] = PacketUtil.getField("LAST_PUT", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
         EOF.setPacketId(++packetId);
     }

--- a/src/main/java/com/actiontech/dble/manager/response/ShowConnectionSQL.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowConnectionSQL.java
@@ -51,7 +51,7 @@ public final class ShowConnectionSQL {
         FIELDS[i] = PacketUtil.getField("SCHEMA", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("EXECUTE_TIME", Fields.FIELD_TYPE_LONGLONG);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSQL.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSQL.java
@@ -50,7 +50,7 @@ public final class ShowSQL {
         FIELDS[i] = PacketUtil.getField("USER", Fields.FIELD_TYPE_VARCHAR);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("EXECUTE_TIME", Fields.FIELD_TYPE_LONGLONG);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSQLHigh.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSQLHigh.java
@@ -60,7 +60,7 @@ public final class ShowSQLHigh {
         FIELDS[i] = PacketUtil.getField("EXECUTE_TIME", Fields.FIELD_TYPE_LONGLONG);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("LAST_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("LAST_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("SQL", Fields.FIELD_TYPE_VAR_STRING);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSQLLarge.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSQLLarge.java
@@ -48,7 +48,7 @@ public final class ShowSQLLarge {
         FIELDS[i] = PacketUtil.getField("ROWS", Fields.FIELD_TYPE_LONGLONG);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("EXECUTE_TIME", Fields.FIELD_TYPE_LONGLONG);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSQLSlow.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSQLSlow.java
@@ -46,7 +46,7 @@ public final class ShowSQLSlow {
         FIELDS[i] = PacketUtil.getField("USER", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("START_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("EXECUTE_TIME", Fields.FIELD_TYPE_LONGLONG);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSQLSumTable.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSQLSumTable.java
@@ -59,7 +59,7 @@ public final class ShowSQLSumTable {
         FIELDS[i] = PacketUtil.getField("RELACOUNT", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("LAST_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("LAST_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
         EOF.setPacketId(++packetId);
     }

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSQLSumUser.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSQLSumUser.java
@@ -81,7 +81,7 @@ public final class ShowSQLSumUser {
         FIELDS[i] = PacketUtil.getField("TTL_COUNT", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("LAST_TIME", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("LAST_TIME", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
         EOF.setPacketId(++packetId);
     }

--- a/src/main/java/com/actiontech/dble/manager/response/ShowServer.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowServer.java
@@ -56,7 +56,7 @@ public final class ShowServer {
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("RELOAD_TIME",
-                Fields.FIELD_TYPE_LONGLONG);
+                Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("ROLLBACK_TIME",

--- a/src/main/java/com/actiontech/dble/manager/response/ShowTime.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowTime.java
@@ -37,7 +37,7 @@ public final class ShowTime {
         byte packetId = 0;
         HEADER.setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("TIMESTAMP", Fields.FIELD_TYPE_LONGLONG);
+        FIELDS[i] = PacketUtil.getField("TIMESTAMP", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i].setPacketId(++packetId);
 
         EOF.setPacketId(++packetId);


### PR DESCRIPTION
Reason:
  Python execute manager sql  would get error when the result set has timestamp
Type:
  BUG
Influences：
  show @@cache
  show @@server
  show @@sql.slow
  show @@sql.high
  show @@sql.large;
  show @@sql.sum.table
  show @@connection.sql
  show @@sql.sum.table
  show @@time.current
  show @@sql.sum.user