### PR TITLE
#609 connection with schema == null can be manager by pool

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/ConMap.java
+++ b/src/main/java/com/actiontech/dble/backend/ConMap.java
@@ -21,26 +21,25 @@ public class ConMap {
     // key--schema
     private final ConcurrentMap<String, ConQueue> items = new ConcurrentHashMap<>();
 
+    private static final String KEY_STRING_FOR_NULL_DATABASE = "KEY FOR NULL";
 
     public ConQueue createAndGetSchemaConQueue(String schema) {
-        ConQueue queue = items.get(schema);
+        ConQueue queue = items.get(schema == null ? KEY_STRING_FOR_NULL_DATABASE : schema);
         if (queue == null) {
             ConQueue newQueue = new ConQueue();
-            queue = items.putIfAbsent(schema, newQueue);
+            queue = items.putIfAbsent(schema == null ? KEY_STRING_FOR_NULL_DATABASE : schema, newQueue);
             return (queue == null) ? newQueue : queue;
         }
         return queue;
     }
 
     public ConQueue getSchemaConQueue(String schema) {
-        return items.get(schema);
+        return items.get(schema == null ? KEY_STRING_FOR_NULL_DATABASE : schema);
     }
 
     public BackendConnection tryTakeCon(final String schema, boolean autoCommit) {
-        if (schema == null) {
-            return null;
-        }
-        final ConQueue queue = items.get(schema);
+
+        final ConQueue queue = items.get(schema == null ? KEY_STRING_FOR_NULL_DATABASE : schema);
         if (queue == null) {
             return null;
         }

--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
@@ -479,19 +479,15 @@ public abstract class PhysicalDatasource {
 
         String errMsg = null;
 
-        if (c.getSchema() != null) {
-            boolean ok;
-            ConQueue queue = this.conMap.createAndGetSchemaConQueue(c.getSchema());
-            if (c.isAutocommit()) {
-                ok = queue.getAutoCommitCons().offer(c);
-            } else {
-                ok = queue.getManCommitCons().offer(c);
-            }
-            if (!ok) {
-                errMsg = "can't return to pool ,so close con " + c;
-            }
+        boolean ok;
+        ConQueue queue = this.conMap.createAndGetSchemaConQueue(c.getSchema());
+        if (c.isAutocommit()) {
+            ok = queue.getAutoCommitCons().offer(c);
         } else {
-            errMsg = "no need to return to pool ,so close con " + c;
+            ok = queue.getManCommitCons().offer(c);
+        }
+        if (!ok) {
+            errMsg = "can't return to pool ,so close con " + c;
         }
         if (errMsg != null) {
             LOGGER.info(errMsg);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/MySQLConnection.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/MySQLConnection.java
@@ -170,10 +170,7 @@ public class MySQLConnection extends BackendAIOConnection {
 
     public void setSchema(String newSchema) {
         String curSchema = schema;
-        if (curSchema == null) {
-            this.schema = newSchema;
-            this.oldSchema = newSchema;
-        } else {
+        if (newSchema != null) {
             this.oldSchema = curSchema;
             this.schema = newSchema;
         }


### PR DESCRIPTION
Reason:
  Improve #607
Type:
  Improve
Influences：
  BackendConnection with schema == null can be returned to pool
  When heartbeat need a backendConnection would get connection form pool