### PR TITLE
#651 Complex query with table alias will cause error when has `

### DIFF
--- a/src/main/java/com/actiontech/dble/plan/node/PlanNode.java
+++ b/src/main/java/com/actiontech/dble/plan/node/PlanNode.java
@@ -544,6 +544,9 @@ public abstract class PlanNode {
      * setAlias for table
      */
     public PlanNode setAlias(String aliasName) {
+        if (aliasName != null && aliasName.charAt(0) == '`') {
+            aliasName = aliasName.substring(1, aliasName.length() - 1);
+        }
         this.alias = aliasName;
         return this;
     }


### PR DESCRIPTION
Reason:
  Bug #651
Type:
  Bug
Influences：
  Add ` check before set to the PlanNode