### PR TITLE
#649 hint ddl no longer update the table meta

### DIFF
--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -306,6 +306,7 @@ public class NonBlockingSession implements Session {
             traceResult.setAdtCommitBegin(new TraceRecord(System.nanoTime()));
         }
     }
+
     public void setFinishedCommitTime() {
         if (traceEnable || SlowQueryLog.getInstance().isEnableSlowLog()) {
             traceResult.setAdtCommitEnd(new TraceRecord(System.nanoTime()));
@@ -924,7 +925,7 @@ public class NonBlockingSession implements Session {
     public void handleSpecial(RouteResultset rrs, String schema, boolean isSuccess) {
         if (rrs.getSchema() != null) {
             handleSpecial(rrs, schema, isSuccess, null);
-        }else{
+        } else {
             LOGGER.info("Hint ddl do not update the meta");
         }
     }

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -922,11 +922,15 @@ public class NonBlockingSession implements Session {
     }
 
     public void handleSpecial(RouteResultset rrs, String schema, boolean isSuccess) {
-        handleSpecial(rrs, schema, isSuccess, null);
+        if (rrs.getSchema() != null) {
+            handleSpecial(rrs, schema, isSuccess, null);
+        }else{
+            LOGGER.info("Hint ddl do not update the meta");
+        }
     }
 
     public void handleSpecial(RouteResultset rrs, String schema, boolean isSuccess, String errInfo) {
-        if (rrs.getSqlType() == ServerParse.DDL) {
+        if (rrs.getSqlType() == ServerParse.DDL && rrs.getSchema() != null) {
             String sql = rrs.getSrcStatement();
             if (source.isTxStart()) {
                 source.setTxStart(false);


### PR DESCRIPTION
Reason:  
  BUG #649 
Type:  
  BUG 649
Influences：  
   hint ddl no longer update the table meta
