### PR TITLE
`show @@connection.sql`.`EXECUTE_TIME` is incorrect

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/response/ShowConnectionSQL.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowConnectionSQL.java
@@ -107,7 +107,7 @@ public final class ShowConnectionSQL {
         row.add(StringUtil.encode(FormatUtil.formatDate(c.getLastReadTime()), charset));
         long rt = c.getLastReadTime();
         long wt = c.getLastWriteTime();
-        row.add(LongUtil.toBytes((wt > rt) ? (wt - rt) : (TimeUtil.currentTimeMillis() - rt)));
+        row.add(LongUtil.toBytes((wt >= rt) ? (wt - rt) : (TimeUtil.currentTimeMillis() - rt)));
         String executeSql = "";
         if (c.getExecuteSql() != null) {
             executeSql = c.getExecuteSql().length() <= 1024 ? c.getExecuteSql() : c.getExecuteSql().substring(0, 1024);


### PR DESCRIPTION
Incorrect result on `show @@connection.sql`.`EXECUTE_TIME` when the execution time of query<1ms 

Reason:  
  BUG #785
Type:  
  BUG
Influences：  
  fix sql execution time is incorrect when execution time less than 1ms
