### PR TITLE
#766 when use zk ipAddress can be config as url

### DIFF
--- a/src/main/java/com/actiontech/dble/config/loader/zkprocess/comm/ZkConfig.java
+++ b/src/main/java/com/actiontech/dble/config/loader/zkprocess/comm/ZkConfig.java
@@ -33,8 +33,7 @@ public final class ZkConfig {
 
     public String getZkURL() {
         return zkProperties == null ? null :
-                zkProperties.getProperty(ClusterParamCfg.CLUSTER_PLUGINS_IP.getKey()) + ":" +
-                        zkProperties.getProperty(ClusterParamCfg.CLUSTER_PLUGINS_PORT.getKey());
+                zkProperties.getProperty(ClusterParamCfg.CLUSTER_PLUGINS_IP.getKey());
     }
 
     public static void initZk(Properties cluterProperties) {


### PR DESCRIPTION
Reason:  
  BUG #766
Type:  
  BUG  
Influences：  
   ZK config use only ipAddress in myid.properties as connect url
