### PR TITLE
Issue 797 remove the metaLock when the ddl session closed before ddl executed

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeDdlHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeDdlHandler.java
@@ -295,4 +295,19 @@ public class MultiNodeDdlHandler extends MultiNodeHandler {
         }
         session.getSource().write(data);
     }
+
+
+    @Override
+    public boolean clearIfSessionClosed(NonBlockingSession nonBlockingSession) {
+        if (nonBlockingSession.closed()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("session closed ,clear resources " + nonBlockingSession);
+            }
+            nonBlockingSession.clearResources(rrs);
+            this.clearResources();
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeDdlHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeDdlHandler.java
@@ -105,7 +105,7 @@ public class MultiNodeDdlHandler extends MultiNodeHandler {
     }
 
     private void innerExecute(BackendConnection conn, RouteResultsetNode node) {
-        if (clearIfSessionClosed(session)) {
+        if (clearIfSessionClosed()) {
             return;
         }
         conn.setResponseHandler(this);
@@ -297,13 +297,12 @@ public class MultiNodeDdlHandler extends MultiNodeHandler {
     }
 
 
-    @Override
-    public boolean clearIfSessionClosed(NonBlockingSession nonBlockingSession) {
-        if (nonBlockingSession.closed()) {
+    public boolean clearIfSessionClosed() {
+        if (session.closed()) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("session closed ,clear resources " + nonBlockingSession);
+                LOGGER.debug("session closed without execution,clear resources " + session);
             }
-            nonBlockingSession.clearResources(rrs);
+            session.clearResources(rrs);
             this.clearResources();
             return true;
         } else {

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
@@ -88,7 +88,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
 
     private void execute(BackendConnection conn) {
         if (session.closed()) {
-            session.clearResources(true);
+            session.clearResources(rrs);
             return;
         }
         conn.setResponseHandler(this);

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -63,6 +63,7 @@ import java.util.concurrent.locks.LockSupport;
 
 import static com.actiontech.dble.meta.PauseEndThreadPool.CONTINUE_TYPE_MULTIPLE;
 import static com.actiontech.dble.meta.PauseEndThreadPool.CONTINUE_TYPE_SINGLE;
+import static com.actiontech.dble.server.parser.ServerParse.DDL;
 
 /**
  * @author mycat
@@ -856,6 +857,13 @@ public class NonBlockingSession implements Session {
         clearHandlesResources();
         source.setTxStart(false);
         source.getAndIncrementXid();
+    }
+
+    public void clearResources(RouteResultset rrs) {
+        clearResources(true);
+        if (rrs.getSqlType() == DDL) {
+            DbleServer.getInstance().getTmManager().removeMetaLock(rrs.getSchema(), rrs.getTable());
+        }
     }
 
     public boolean closed() {


### PR DESCRIPTION
Reason:  
  BUG #797 
Type:  
  BUG  
Influences：  
    Remove the metaLock when the ddl session closed before ddl executed
