### PR TITLE
statement can't write to slow log when execution result  is incorrect

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeSelectHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeSelectHandler.java
@@ -66,7 +66,7 @@ public class MultiNodeSelectHandler extends MultiNodeQueryHandler {
                     return;
                 }
                 session.resetMultiStatementStatus();
-                handleEndPacket(err.toBytes(), AutoTxOperation.ROLLBACK, conn);
+                handleEndPacket(err.toBytes(), AutoTxOperation.ROLLBACK, conn, false);
             } else {
                 if (!fieldsReturned) {
                     fieldsReturned = true;

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
@@ -151,9 +151,8 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
         if (buffer != null) {
             /* SELECT 9223372036854775807 + 1;    response: field_count, field, eof, err */
             buffer = source.writeToBuffer(errPkg.toBytes(), allocBuffer());
-            session.setResponseTime();
+            session.setResponseTime(false);
             source.write(buffer);
-
         } else {
             errPkg.write(source);
         }
@@ -195,7 +194,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
             source.setLastInsertId(ok.getInsertId());
             session.setBackendResponseEndTime((MySQLConnection) conn);
             session.releaseConnectionIfSafe(conn, false);
-            session.setResponseTime();
+            session.setResponseTime(true);
             session.multiStatementPacket(ok, packetId);
             boolean multiStatementFlag = session.getIsMultiStatement().get();
             doSqlStat();
@@ -213,7 +212,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
 
         session.setBackendResponseEndTime((MySQLConnection) conn);
         session.releaseConnectionIfSafe(conn, false);
-        session.setResponseTime();
+        session.setResponseTime(false);
         session.multiStatementPacket(errPacket, packetId);
         boolean multiStatementFlag = session.getIsMultiStatement().get();
         doSqlStat();
@@ -242,7 +241,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
         session.multiStatementPacket(eof, packetId);
         ServerConnection source = session.getSource();
         buffer = source.writeToBuffer(eof, allocBuffer());
-        session.setResponseTime();
+        session.setResponseTime(true);
         boolean multiStatementFlag = session.getIsMultiStatement().get();
         doSqlStat();
         source.write(buffer);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/OutputHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/OutputHandler.java
@@ -175,7 +175,7 @@ public class OutputHandler extends BaseDMLHandler {
             byte[] eof = eofPacket.toBytes();
             buffer = source.writeToBuffer(eof, buffer);
             session.setHandlerEnd(this);
-            session.setResponseTime();
+            session.setResponseTime(true);
             boolean multiStatementFlag = session.getIsMultiStatement().get();
             source.write(buffer);
             session.multiStatementNextSql(multiStatementFlag);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalAutoCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalAutoCommitNodesHandler.java
@@ -14,8 +14,8 @@ public class NormalAutoCommitNodesHandler extends NormalCommitNodesHandler {
     }
 
     @Override
-    protected void setResponseTime() {
+    protected void setResponseTime(boolean isSuccess) {
         session.setFinishedCommitTime();
-        session.setResponseTime();
+        session.setResponseTime(isSuccess);
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalAutoRollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalAutoRollbackNodesHandler.java
@@ -46,7 +46,7 @@ public class NormalAutoRollbackNodesHandler extends NormalRollbackNodesHandler {
     }
 
     @Override
-    protected void setResponseTime() {
-        session.setResponseTime();
+    protected void setResponseTime(boolean isSuccess) {
+        session.setResponseTime(isSuccess);
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalCommitNodesHandler.java
@@ -59,7 +59,7 @@ public class NormalCommitNodesHandler extends AbstractCommitNodesHandler {
             if (sendData == null) {
                 sendData = session.getOkByteArray();
             }
-            cleanAndFeedback();
+            cleanAndFeedback(true);
         }
     }
 
@@ -71,7 +71,7 @@ public class NormalCommitNodesHandler extends AbstractCommitNodesHandler {
         this.setFail(errMsg);
         conn.close("commit response error");
         if (decrementCountBy(1)) {
-            cleanAndFeedback();
+            cleanAndFeedback(false);
         }
     }
 
@@ -81,7 +81,7 @@ public class NormalCommitNodesHandler extends AbstractCommitNodesHandler {
         this.setFail(e.getMessage());
         conn.close("Commit connection Error");
         if (decrementCountBy(1)) {
-            cleanAndFeedback();
+            cleanAndFeedback(false);
         }
     }
 
@@ -93,18 +93,18 @@ public class NormalCommitNodesHandler extends AbstractCommitNodesHandler {
         this.setFail(reason);
         conn.close("commit connection closed");
         if (decrementCountBy(1)) {
-            cleanAndFeedback();
+            cleanAndFeedback(false);
         }
     }
 
-    private void cleanAndFeedback() {
+    private void cleanAndFeedback(boolean isSuccess) {
         byte[] send = sendData;
         // clear all resources
         session.clearResources(false);
         if (session.closed()) {
             return;
         }
-        setResponseTime();
+        setResponseTime(isSuccess);
         if (this.isFail()) {
             createErrPkg(error).write(session.getSource());
         } else {
@@ -114,6 +114,6 @@ public class NormalCommitNodesHandler extends AbstractCommitNodesHandler {
         }
     }
 
-    protected void setResponseTime() {
+    protected void setResponseTime(boolean isSuccess) {
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalRollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalRollbackNodesHandler.java
@@ -57,7 +57,7 @@ public class NormalRollbackNodesHandler extends AbstractRollbackNodesHandler {
             if (sendData == null) {
                 sendData = OkPacket.OK;
             }
-            cleanAndFeedback();
+            cleanAndFeedback(true);
         }
     }
 
@@ -67,7 +67,7 @@ public class NormalRollbackNodesHandler extends AbstractRollbackNodesHandler {
             if (sendData == null) {
                 sendData = session.getOkByteArray();
             }
-            cleanAndFeedback();
+            cleanAndFeedback(true);
         }
     }
 
@@ -79,7 +79,7 @@ public class NormalRollbackNodesHandler extends AbstractRollbackNodesHandler {
         this.setFail(errMsg);
         conn.close("rollback error response"); //quit to rollback
         if (decrementCountBy(1)) {
-            cleanAndFeedback();
+            cleanAndFeedback(false);
         }
     }
 
@@ -90,7 +90,7 @@ public class NormalRollbackNodesHandler extends AbstractRollbackNodesHandler {
         this.setFail(errMsg);
         conn.close("rollback connection error"); //quit if not rollback
         if (decrementCountBy(1)) {
-            cleanAndFeedback();
+            cleanAndFeedback(false);
         }
     }
 
@@ -99,18 +99,18 @@ public class NormalRollbackNodesHandler extends AbstractRollbackNodesHandler {
         // quitted
         this.setFail(reason);
         if (decrementCountBy(1)) {
-            cleanAndFeedback();
+            cleanAndFeedback(false);
         }
     }
 
-    private void cleanAndFeedback() {
+    private void cleanAndFeedback(boolean isOk) {
         byte[] send = sendData;
         // clear all resources
         session.clearResources(false);
         if (session.closed()) {
             return;
         }
-        setResponseTime();
+        setResponseTime(isOk);
         if (this.isFail()) {
             createErrPkg(error).write(session.getSource());
         } else {
@@ -120,6 +120,6 @@ public class NormalRollbackNodesHandler extends AbstractRollbackNodesHandler {
         }
     }
 
-    protected void setResponseTime() {
+    protected void setResponseTime(boolean isSuccess) {
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XAAutoCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XAAutoCommitNodesHandler.java
@@ -28,8 +28,8 @@ public class XAAutoCommitNodesHandler extends XACommitNodesHandler {
     }
 
     @Override
-    protected void setResponseTime() {
+    protected void setResponseTime(boolean isSuccess) {
         session.setFinishedCommitTime();
-        session.setResponseTime();
+        session.setResponseTime(isSuccess);
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XAAutoRollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XAAutoRollbackNodesHandler.java
@@ -46,7 +46,7 @@ public class XAAutoRollbackNodesHandler extends XARollbackNodesHandler {
     }
 
     @Override
-    protected void setResponseTime() {
-        session.setResponseTime();
+    protected void setResponseTime(boolean isSuccess) {
+        session.setResponseTime(isSuccess);
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -329,7 +329,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
         }
     }
 
-    protected void setResponseTime() {
+    protected void setResponseTime(boolean isSuccess) {
     }
 
     protected void nextParse() {
@@ -350,7 +350,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
             if (session.closed()) {
                 return;
             }
-            setResponseTime();
+            setResponseTime(true);
             byte[] send = sendData;
             session.getSource().write(send);
 
@@ -374,7 +374,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
                 byte[] toSend = sendData;
                 session.clearResources(false);
                 if (!session.closed()) {
-                    setResponseTime();
+                    setResponseTime(true);
                     session.getSource().write(toSend);
                 }
             }
@@ -382,7 +382,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
             // need to rollback;
         } else {
             XAStateLog.saveXARecoveryLog(session.getSessionXaID(), session.getXaState());
-            setResponseTime();
+            setResponseTime(true);
             session.getSource().write(sendData);
             LOGGER.info("cleanAndFeedback:" + error);
 

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XARollbackNodesHandler.java
@@ -87,7 +87,7 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
     }
 
 
-    protected void setResponseTime() {
+    protected void setResponseTime(boolean isSuccess) {
     }
 
     private boolean executeRollback(MySQLConnection mysqlCon, int position) {
@@ -360,7 +360,7 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
             if (session.closed()) {
                 return;
             }
-            setResponseTime();
+            setResponseTime(true);
             byte[] send = sendData;
             session.getSource().write(send);
 
@@ -388,7 +388,7 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
                 byte[] toSend = sendData;
                 session.clearResources(false);
                 if (!session.closed()) {
-                    setResponseTime();
+                    setResponseTime(true);
                     session.getSource().write(toSend);
                 }
             }
@@ -402,7 +402,7 @@ public class XARollbackNodesHandler extends AbstractRollbackNodesHandler {
             if (session.closed()) {
                 return;
             }
-            setResponseTime();
+            setResponseTime(true);
             session.getSource().write(sendData);
 
         }

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -271,12 +271,14 @@ public class NonBlockingSession implements Session {
         provider.allBackendConnReceive(source.getId());
     }
 
-    public void setResponseTime() {
+    public void setResponseTime(boolean isSuccess) {
         long responseTime = 0;
         if (traceEnable || SlowQueryLog.getInstance().isEnableSlowLog()) {
             responseTime = System.nanoTime();
             traceResult.setVeryEnd(responseTime);
-            SlowQueryLog.getInstance().putSlowQueryLog(this.source, (TraceResult) traceResult.clone());
+            if (isSuccess) {
+                SlowQueryLog.getInstance().putSlowQueryLog(this.source, (TraceResult) traceResult.clone());
+            }
         }
         if (!timeCost) {
             return;


### PR DESCRIPTION
Reason:  
  BUG #807
Type:  
  BUG
Influences：  
  fix bug that statement can't write to slow log when execution result  is incorrect
