### PR TITLE
Inner 151 change online key/value when use ucore cluster

### DIFF
--- a/src/main/java/com/actiontech/dble/config/loader/ucoreprocess/ClusterUcoreSender.java
+++ b/src/main/java/com/actiontech/dble/config/loader/ucoreprocess/ClusterUcoreSender.java
@@ -425,7 +425,8 @@ public final class ClusterUcoreSender {
         Iterator<Map.Entry<String, String>> iterator = expectedMap.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<String, String> entry = iterator.next();
-            if (!currentMap.containsKey(entry.getKey())) {
+            if (!currentMap.containsKey(entry.getKey()) ||
+                    (currentMap.containsKey(entry.getKey()) && !currentMap.get(entry.getKey()).equals(entry.getValue()))) {
                 iterator.remove();
             }
         }

--- a/src/main/java/com/actiontech/dble/config/loader/ucoreprocess/listen/UOffLineListener.java
+++ b/src/main/java/com/actiontech/dble/config/loader/ucoreprocess/listen/UOffLineListener.java
@@ -114,7 +114,8 @@ public class UOffLineListener implements Runnable {
                 }
 
                 for (Map.Entry<String, String> en : onlineMap.entrySet()) {
-                    if (!newMap.containsKey(en.getKey())) {
+                    if (!newMap.containsKey(en.getKey()) ||
+                            (newMap.containsKey(en.getKey()) && !newMap.get(en.getKey()).equals(en.getValue()))) {
                         String serverId = en.getKey().split("/")[en.getKey().split("/").length - 1];
                         checkDDLAndRelease(serverId);
                         checkBinlogStatusRelease(serverId);

--- a/src/main/java/com/actiontech/dble/server/status/OnlineLockStatus.java
+++ b/src/main/java/com/actiontech/dble/server/status/OnlineLockStatus.java
@@ -21,6 +21,7 @@ public final class OnlineLockStatus {
     private static final Logger LOGGER = LoggerFactory.getLogger(OnlineLockStatus.class);
     private volatile UDistributeLock onlineLock = null;
     private volatile boolean onlineInited = false;
+
     private OnlineLockStatus() {
     }
 
@@ -42,7 +43,7 @@ public final class OnlineLockStatus {
         }
         onlineLock = new UDistributeLock(UcorePathUtil.getOnlinePath(UcoreConfig.getInstance().
                 getValue(ClusterParamCfg.CLUSTER_CFG_MYID)),
-                UcoreConfig.getInstance().getValue(ClusterParamCfg.CLUSTER_CFG_MYID), 6);
+                "" + System.currentTimeMillis(), 6);
         int time = 0;
         while (!onlineLock.acquire()) {
             time++;


### PR DESCRIPTION
Reason:  
  BUG #Inner 151
Type:  
  BUG
Influences：  
   Change online key/value into timestamp,only waiting for the same timestamp,when the timestamp changed,the cluster option do not wait for this one
