### PR TITLE
#897 terminate all the result before a JoinNode send rowEof to nextHa…

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/join/JoinHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/join/JoinHandler.java
@@ -217,8 +217,8 @@ public class JoinHandler extends OwnThreadDMLHandler {
                 }
             }
             session.setHandlerEnd(this);
-            nextHandler.rowEofResponse(null, isLeft, conn);
             HandlerTool.terminateHandlerTree(this);
+            nextHandler.rowEofResponse(null, isLeft, conn);
         } catch (Exception e) {
             String msg = "join thread error, " + e.getLocalizedMessage();
             LOGGER.info(msg, e);


### PR DESCRIPTION
Reason:  
  BUG #897
Type:  
  BUG  
Influences：  
   terminate all the result before a JoinNode send rowEof to nextHandler
