### PR TITLE
#919 not split the multiStatement when the login flag does not set th…

### DIFF
--- a/src/main/java/com/actiontech/dble/config/Capabilities.java
+++ b/src/main/java/com/actiontech/dble/config/Capabilities.java
@@ -85,4 +85,6 @@ public final class Capabilities {
 
     public static final int CLIENT_PLUGIN_AUTH = 0x00080000; // 524288
 
+    public static final int CLIENT_MULTIPLE_STATEMENTS = 0x00010000;
+
 }

--- a/src/main/java/com/actiontech/dble/net/FrontendConnection.java
+++ b/src/main/java/com/actiontech/dble/net/FrontendConnection.java
@@ -54,6 +54,7 @@ public abstract class FrontendConnection extends AbstractConnection {
     protected boolean isAuthenticated;
     private boolean userReadOnly = true;
     private boolean sessionReadOnly = false;
+    private boolean multStatementAllow = false;
 
     public FrontendConnection(NetworkChannel channel) throws IOException {
         super(channel);
@@ -118,6 +119,13 @@ public abstract class FrontendConnection extends AbstractConnection {
         this.loadDataInfileHandler = loadDataInfileHandler;
     }
 
+    public boolean isMultStatementAllow() {
+        return multStatementAllow;
+    }
+
+    public void setMultStatementAllow(boolean multStatementAllow) {
+        this.multStatementAllow = multStatementAllow;
+    }
     public void setQueryHandler(FrontendQueryHandler queryHandler) {
         this.queryHandler = queryHandler;
     }

--- a/src/main/java/com/actiontech/dble/net/handler/FrontendAuthenticator.java
+++ b/src/main/java/com/actiontech/dble/net/handler/FrontendAuthenticator.java
@@ -199,6 +199,7 @@ public class FrontendAuthenticator implements NIOHandler {
         source.setSchema(auth.getDatabase());
         source.initCharsetIndex(auth.getCharsetIndex());
         source.setHandler(successCommendHandler());
+        source.setMultStatementAllow(auth.isMultStatementAllow());
 
         if (LOGGER.isDebugEnabled()) {
             StringBuilder s = new StringBuilder();

--- a/src/main/java/com/actiontech/dble/net/mysql/AuthPacket.java
+++ b/src/main/java/com/actiontech/dble/net/mysql/AuthPacket.java
@@ -50,6 +50,9 @@ public class AuthPacket extends MySQLPacket {
     private String database;
     private String authPlugin;
 
+
+    private boolean multStatementAllow = false;
+
     public void read(byte[] data) {
         MySQLMessage mm = new MySQLMessage(data);
         packetLength = mm.readUB3();
@@ -73,6 +76,10 @@ public class AuthPacket extends MySQLPacket {
             if (database != null && DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames()) {
                 database = database.toLowerCase();
             }
+        }
+
+        if ((clientFlags & Capabilities.CLIENT_MULTIPLE_STATEMENTS) != 0) {
+            multStatementAllow = true;
         }
 
         if ((clientFlags & CLIENT_PLUGIN_AUTH) != 0) {
@@ -216,5 +223,9 @@ public class AuthPacket extends MySQLPacket {
 
     public String getAuthPlugin() {
         return authPlugin;
+    }
+
+    public boolean isMultStatementAllow() {
+        return multStatementAllow;
     }
 }

--- a/src/main/java/com/actiontech/dble/server/ServerQueryHandler.java
+++ b/src/main/java/com/actiontech/dble/server/ServerQueryHandler.java
@@ -48,7 +48,7 @@ public class ServerQueryHandler implements FrontendQueryHandler {
             sql = source.getSession2().getRemingSql();
         }
         //Preliminary judgment of multi statement
-        if (source.getSession2().generalNextStatement(sql)) {
+        if (source.isMultStatementAllow() && source.getSession2().generalNextStatement(sql)) {
             sql = sql.substring(0, ParseUtil.findNextBreak(sql));
         }
         source.setExecuteSql(sql);


### PR DESCRIPTION
Reason:  
  BUG #919 
Type:   
  BUG  
Influences：  
   Alow procedure create when the CLIENT_MULTI_STATEMENTS is not set for the client,when the CLIENT_MULTI_STATEMENTS set 1,the procedure still will split by ';'
