### PR TITLE
pr for bug #984

### DIFF
--- a/src/main/java/com/actiontech/dble/meta/table/GetNodeTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/meta/table/GetNodeTablesHandler.java
@@ -27,7 +27,6 @@ public abstract class GetNodeTablesHandler {
     protected static final Logger LOGGER = LoggerFactory.getLogger(GetNodeTablesHandler.class);
     protected static final String SQL = "show full tables where Table_type ='BASE TABLE' ";
     protected String dataNode;
-    private volatile boolean finished = false;
 
     GetNodeTablesHandler(String dataNode) {
         this.dataNode = dataNode;
@@ -36,11 +35,6 @@ public abstract class GetNodeTablesHandler {
     protected abstract void handleTables(String table);
 
     protected abstract void handleFinished();
-
-    public boolean isFinished() {
-        return finished;
-    }
-
     public void execute() {
         PhysicalDBNode dn = DbleServer.getInstance().getConfig().getDataNodes().get(dataNode);
         String mysqlShowTableCol = "Tables_in_" + dn.getDatabase();
@@ -85,7 +79,6 @@ public abstract class GetNodeTablesHandler {
                     AlertUtil.alert(AlarmCode.DATA_NODE_LACK, Alert.AlertLevel.WARN, "{" + key + "} is lack", "mysql", ds.getConfig().getId(), labels);
                     ToResolveContainer.DATA_NODE_LACK.add(key);
                 }
-                finished = true;
                 handleFinished();
                 return;
             }
@@ -104,7 +97,6 @@ public abstract class GetNodeTablesHandler {
                 }
                 handleTables(table);
             }
-            finished = true;
             handleFinished();
         }
     }

--- a/src/main/java/com/actiontech/dble/meta/table/GetSchemaDefaultNodeTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/meta/table/GetSchemaDefaultNodeTablesHandler.java
@@ -14,6 +14,8 @@ public class GetSchemaDefaultNodeTablesHandler extends GetNodeTablesHandler {
 
     private SchemaConfig config;
     private MultiTablesMetaHandler multiTablesMetaHandler;
+    private volatile boolean finished = false;
+
     GetSchemaDefaultNodeTablesHandler(MultiTablesMetaHandler multiTablesMetaHandler, SchemaConfig config) {
         super(config.getDataNode());
         this.multiTablesMetaHandler = multiTablesMetaHandler;
@@ -35,6 +37,11 @@ public class GetSchemaDefaultNodeTablesHandler extends GetNodeTablesHandler {
 
     @Override
     protected void handleFinished() {
+        finished = true;
         multiTablesMetaHandler.showTablesFinished();
+    }
+
+    public boolean isFinished() {
+        return finished;
     }
 }

--- a/src/main/java/com/actiontech/dble/meta/table/GetSpecialNodeTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/meta/table/GetSpecialNodeTablesHandler.java
@@ -18,6 +18,7 @@ public class GetSpecialNodeTablesHandler extends GetNodeTablesHandler {
     private AbstractTablesMetaHandler handler;
     private Set<String> tables;
     private volatile Set<String> existsTables = new HashSet<>();
+    private volatile boolean finished = false;
     GetSpecialNodeTablesHandler(AbstractTablesMetaHandler handler, Set<String> tables, String dataNode) {
         super(dataNode);
         this.handler = handler;
@@ -50,6 +51,10 @@ public class GetSpecialNodeTablesHandler extends GetNodeTablesHandler {
                 }
             }
         }
+        finished = true;
         handler.showTablesFinished();
+    }
+    public boolean isFinished() {
+        return finished;
     }
 }


### PR DESCRIPTION
Reason:  
  BUG #984
Type:  
  BUG
Influences：  
   fix logic

If a physical datanode has no tables.
This may happen:
AbstractTablesMetaHandler ->listExistTables
thread 1:
before lock,
switch to thread 2.
thread 2:
GetNodeTablesHandler->onResult
finished = true;
switch to thread 1.
thread 1:
listExistTables return &countdown()
multiTablesMetaHandler.countDownShardTable()

and at the same time,thread 2:
handleFinished->GetSpecialNodeTablesHandler->handleFinished()
handlerTable->multiTablesMetaHandler.checkTableConsistent()

so thread1 and thread2 will may modify a same list