### PR TITLE
#989 global table switch back conn in transaction for complex query

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/HandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/HandlerBuilder.java
@@ -39,6 +39,10 @@ public class HandlerBuilder {
         }
     }
 
+    synchronized void removeRrs(RouteResultsetNode rrsNode) {
+        rrsNodes.remove(rrsNode);
+    }
+
     /**
      * start all leaf handler of children of special handler
      */

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/NoNameNodeHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/NoNameNodeHandlerBuilder.java
@@ -12,6 +12,7 @@ import com.actiontech.dble.config.model.SchemaConfig;
 import com.actiontech.dble.plan.node.NoNameNode;
 import com.actiontech.dble.route.RouteResultsetNode;
 import com.actiontech.dble.server.NonBlockingSession;
+import com.actiontech.dble.server.parser.ServerParse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +51,8 @@ class NoNameNodeHandlerBuilder extends BaseHandlerBuilder {
         String sql = visitor.getSql().toString();
         String schema = session.getSource().getSchema();
         SchemaConfig schemaConfig = schemaConfigMap.get(schema);
-        RouteResultsetNode[] rrss = getTableSources(schemaConfig.getAllDataNodes(), sql);
+        String randomDatenode = getRandomNode(schemaConfig.getAllDataNodes());
+        RouteResultsetNode[] rrss = new RouteResultsetNode[]{new RouteResultsetNode(randomDatenode, ServerParse.SELECT, sql)};
         hBuilder.checkRRSs(rrss);
         MultiNodeMergeHandler mh = new MultiNodeMergeHandler(getSequenceId(), rrss, session.getSource().isAutocommit() && !session.getSource().isTxStart(),
                 session, null);


### PR DESCRIPTION
Reason:  
  BUG #989
Type:
  BUG
Influences：
   fix when in transaction,global table has use a random node,next select query will use the same node
