### PR TITLE
Update CharsetUtil.java

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/CharsetUtil.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/CharsetUtil.java
@@ -282,7 +282,7 @@ public final class CharsetUtil {
         CHARSET_TO_JAVA.put("macroman", "MacRoman");
         CHARSET_TO_JAVA.put("cp852", "Cp852");
         CHARSET_TO_JAVA.put("latin7", "ISO8859_13");
-        CHARSET_TO_JAVA.put("utf8mb4", "MacCentralEurope"); //?
+        CHARSET_TO_JAVA.put("utf8mb4", "UTF-8"); //https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-charsets.html
         CHARSET_TO_JAVA.put("cp1251", "Cp1251");
         CHARSET_TO_JAVA.put("utf16", "UTF-16");
         CHARSET_TO_JAVA.put("utf16le", "UTF-16LE");


### PR DESCRIPTION
fix #995. Set MySQL's utf8mb4 character set maps to Java's UTF-8 character encoding.

Reason:  
  BUG #995 
Type:  
  BUG/Improve  
Influences：  
   fix incorrect decoding before route. ATTENSION! If your sharding column has non-ASCII characters, you will have different route result after this patch. In other words, this patch breaks backward compatibility.