### PR TITLE
miss cache although data has been put in RocksDB cache

### DIFF
--- a/src/main/java/com/actiontech/dble/cache/impl/RocksDBPool.java
+++ b/src/main/java/com/actiontech/dble/cache/impl/RocksDBPool.java
@@ -43,7 +43,7 @@ public class RocksDBPool implements CachePool {
     public Object get(Object key) {
         try {
             byte[] keyBytes = fst.asByteArray(key);
-            byte[] bytes = cache.get(fst.asByteArray(keyBytes));
+            byte[] bytes = cache.get(keyBytes);
             if (bytes != null) {
                 Object cached = fst.asObject(bytes);
 


### PR DESCRIPTION
Reason:  
  BUG.  
Type:  
  BUG 
Influences：  
  miss cache although data has been put in RocksDB cache
