### PR TITLE
explain got different result when "join" between ER tables whether use uppercase as table alias

### DIFF
--- a/src/main/java/com/actiontech/dble/plan/optimizer/ERJoinChooser.java
+++ b/src/main/java/com/actiontech/dble/plan/optimizer/ERJoinChooser.java
@@ -581,8 +581,13 @@ public class ERJoinChooser {
                 }
                 return null;
             } else {
-                if (!StringUtil.equals(table, child.getAlias()))
-                    return null;
+                if (DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames()) {
+                    if (!StringUtil.equalsIgnoreCase(table, child.getAlias()))
+                        return null;
+                } else {
+                    if (!StringUtil.equals(table, child.getAlias()))
+                        return null;
+                }
                 for (Entry<NamedField, Item> entry : child.getOuterFields().entrySet()) {
                     if (StringUtil.equalsIgnoreCase(colName, entry.getKey().getName())) {
                         return entry.getValue();


### PR DESCRIPTION
Reason:  
  BUG #1057. 
Type:  
  BUG
Influences：  
  explain got different result when "join" between ER tables whether use uppercase as table alias
