### PR TITLE
#1070 remove connection for queue even the schema is null

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
@@ -478,11 +478,9 @@ public abstract class PhysicalDatasource {
     public void connectionClosed(BackendConnection conn) {
         //only used in mysqlConneciton synchronized function
         this.connectionCount.decrementAndGet();
-        if (conn.getSchema() != null) {
-            ConQueue queue = this.conMap.getSchemaConQueue(conn.getSchema());
-            if (queue != null) {
-                queue.removeCon(conn);
-            }
+        ConQueue queue = this.conMap.getSchemaConQueue(conn.getSchema());
+        if (queue != null) {
+            queue.removeCon(conn);
         }
     }
 


### PR DESCRIPTION
Reason:  
  BUG #1070 
Type:  
  BUG  
Influences：  
   Remove connection for queue even the schema is null
