### PR TITLE
fix #1087 Improve error tips when using correlated subquery in the SELECT clause

### DIFF
--- a/src/main/java/com/actiontech/dble/plan/visitor/MySQLPlanNodeVisitor.java
+++ b/src/main/java/com/actiontech/dble/plan/visitor/MySQLPlanNodeVisitor.java
@@ -357,6 +357,7 @@ public class MySQLPlanNodeVisitor {
                 setSubQueryNode(args);
             }
         }
+        tableNode.setCorrelatedSubQuery(selItem.isCorrelatedSubQuery());
     }
 
     private void handleWhereCondition(SQLExpr whereExpr) {


### PR DESCRIPTION
Reason:  
  Improve error tips when using correlated subquery in the SELECT clause
Type:  
  BUG/Improve  
Influences：  
   fix #1087 
Test:
After this commit, 
```
mysql> SELECT COUNT(*) AS TEMP2,
    ->        (SELECT COUNT(*)
    ->           FROM TK_TEST s
    ->          WHERE MONTH(s.SENDING_DATE) = MONTH(t.SENDING_DATE)
    ->        ) AS TEMP1
    -> FROM TK_TEST t;
ERROR 1105 (HY000): Correlated Sub Queries is not supported
```