### PR TITLE
support apostrophe in statement that contains 'where schema=? and table=?'

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/response/ShowHelp.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowHelp.java
@@ -140,8 +140,8 @@ public final class ShowHelp {
 
         HELPS.put("show @@cost_time", "Report cost time of query , contains back End ,front End and over all");
         HELPS.put("show @@thread_used", "Report usage of threads, for optimize performance ");
-        HELPS.put("show @@dataNodes where schema=? and table=?", "Report the data nodes info of a table");
-        HELPS.put("show @@algorithm where schema=? and table=?", "Report the algorithm info of a table");
+        HELPS.put("show @@dataNodes where schema='?' and table='?'", "Report the data nodes info of a table");
+        HELPS.put("show @@algorithm where schema='?' and table='?'", "Report the algorithm info of a table");
         HELPS.put("show @@ddl", "Report all ddl info in progress");
         // switch
         HELPS.put("switch @@datasource name:index", "Switch dataSource");
@@ -149,7 +149,7 @@ public final class ShowHelp {
         // kill
         HELPS.put("kill @@connection id1,id2,...", "Kill the specified connections");
         HELPS.put("kill @@xa_session id1,id2,...", "Kill the specified sessions that commit/rollback xa transaction in the background");
-        HELPS.put("kill @@ddl_lock where schema=? and table=?", "Kill ddl lock held by the specified ddl");
+        HELPS.put("kill @@ddl_lock where schema='?' and table='?'", "Kill ddl lock held by the specified ddl");
 
         // stop
         HELPS.put("stop @@heartbeat name:time", "Pause dataNode heartbeat");

--- a/src/main/java/com/actiontech/dble/manager/response/ShowTableAlgorithm.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowTableAlgorithm.java
@@ -57,7 +57,7 @@ public final class ShowTableAlgorithm {
     public static void execute(ManagerConnection c, String tableInfo) {
         Matcher ma = PATTERN_FOR_TABLE_INFO.matcher(tableInfo);
         if (!ma.matches()) {
-            c.writeErrMessage(ErrorCode.ER_UNKNOWN_ERROR, "The Correct Query Format Is:show @@algorithm where schema=? and table =?");
+            c.writeErrMessage(ErrorCode.ER_UNKNOWN_ERROR, "The Correct Query Format Is:show @@algorithm where schema='?' and table ='?'");
             return;
         }
         String schemaName = ma.group(2);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowTableDataNode.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowTableDataNode.java
@@ -70,7 +70,7 @@ public final class ShowTableDataNode {
     public static void execute(ManagerConnection c, String tableInfo) {
         Matcher ma = PATTERN_FOR_TABLE_INFO.matcher(tableInfo);
         if (!ma.matches()) {
-            c.writeErrMessage(ErrorCode.ER_UNKNOWN_ERROR, "The Correct Query Format Is:show @@datanodes where schema=? and table =?");
+            c.writeErrMessage(ErrorCode.ER_UNKNOWN_ERROR, "The Correct Query Format Is:show @@datanodes where schema='?' and table ='?'");
             return;
         }
         String schemaName = ma.group(2);

--- a/src/main/java/com/actiontech/dble/route/parser/ManagerParseShow.java
+++ b/src/main/java/com/actiontech/dble/route/parser/ManagerParseShow.java
@@ -79,8 +79,8 @@ public final class ManagerParseShow {
     public static final int PROCESS_LIST = 62;
     public static final int SESSION_XA = 63;
 
-    public static final Pattern PATTERN_FOR_TABLE_INFO = Pattern.compile("^(\\s*schema\\s*=\\s*)'([a-zA-Z_0-9]+)'" +
-            "(\\s+and\\s+table\\s*=\\s*)'([a-zA-Z_0-9]+)'\\s*$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_FOR_TABLE_INFO = Pattern.compile("^\\s*schema\\s*=\\s*('?)([a-zA-Z_0-9]+)\\1" +
+            "\\s+and\\s+table\\s*=\\s*('?)([a-zA-Z_0-9]+)\\3\\s*$", Pattern.CASE_INSENSITIVE);
 
     public static int parse(String stmt, int offset) {
         int i = offset;

--- a/src/main/java/com/actiontech/dble/route/parser/ManagerParseShow.java
+++ b/src/main/java/com/actiontech/dble/route/parser/ManagerParseShow.java
@@ -79,8 +79,8 @@ public final class ManagerParseShow {
     public static final int PROCESS_LIST = 62;
     public static final int SESSION_XA = 63;
 
-    public static final Pattern PATTERN_FOR_TABLE_INFO = Pattern.compile("^(\\s*schema\\s*=\\s*)([a-zA-Z_0-9]+)" +
-            "(\\s+and\\s+table\\s*=\\s*)([a-zA-Z_0-9]+)\\s*$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_FOR_TABLE_INFO = Pattern.compile("^(\\s*schema\\s*=\\s*)'([a-zA-Z_0-9]+)'" +
+            "(\\s+and\\s+table\\s*=\\s*)'([a-zA-Z_0-9]+)'\\s*$", Pattern.CASE_INSENSITIVE);
 
     public static int parse(String stmt, int offset) {
         int i = offset;


### PR DESCRIPTION
Reason:  
  Improve #1086 .
Type:  
  Improve
Influences：  

The affected statement and compatible with no apostrophe:
1. show @@dataNodes where schema='?' and table='?'
2. show @@algorithm where schema='?' and table='?'
3. kill @@ddl_lock where schema='?' and table='?'
