### PR TITLE
 #1114  when running sysbench oltp test ,XA transaction can't restore after restarting dble  #1116  when complex cross join contained in a xa-transaction, the statement commit can't return

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.actiontech</groupId>
     <artifactId>dble</artifactId>
-    <version>9.9.9.9</version>
+    <version>2.19.01.0</version>
     <packaging>jar</packaging>
     <name>dble-server</name>
     <description>The project of dble-server</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.actiontech</groupId>
     <artifactId>dble</artifactId>
-    <version>2.19.01.0</version>
+    <version>9.9.9.9</version>
     <packaging>jar</packaging>
     <name>dble-server</name>
     <description>The project of dble-server</description>

--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -1014,8 +1014,8 @@ public final class DbleServer {
                     participantLogEntry.getTxState() != TxState.TX_PREPARE_UNCONNECT_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACKING_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACK_FAILED_STATE &&
-					participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE && 
-					participantLogEntry.getTxState() != TxState.TX_ENDED_STATE) {
+                    participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE &&
+                    participantLogEntry.getTxState() != TxState.TX_ENDED_STATE) {
                 continue;
             }
             finished = false;

--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -1014,7 +1014,8 @@ public final class DbleServer {
                     participantLogEntry.getTxState() != TxState.TX_PREPARE_UNCONNECT_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACKING_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACK_FAILED_STATE &&
-                    participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE) {
+					participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE && 
+					participantLogEntry.getTxState() != TxState.TX_ENDED_STATE) {
                 continue;
             }
             finished = false;

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/BaseSelectHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/BaseSelectHandler.java
@@ -54,7 +54,8 @@ public class BaseSelectHandler extends BaseDMLHandler {
         } else {
             PhysicalDBNode dn = DbleServer.getInstance().getConfig().getDataNodes().get(rrss.getName());
             //autocommit is session.getSource().isAutocommit() && !session.getSource().isTxStart()
-            final BackendConnection newConn = dn.getConnection(dn.getDatabase(), autocommit, rrss.getRunOnSlave(), rrss);
+            final BackendConnection newConn = dn.getConnection(dn.getDatabase(),
+                    autocommit && !session.getSource().isTxStart(), rrss.getRunOnSlave(), rrss);
             session.bindConnection(rrss, newConn);
             return (MySQLConnection) newConn;
         }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -143,6 +143,12 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
                     }
                 });
             }
+        } else if (state == TxState.TX_INITIALIZE_STATE) {
+            String errMsg = "The XA state of this session is tx_initialize_state, should not go to this branch";
+            LOGGER.error(errMsg);
+            session.getSource().write(makeErrorPacket(errMsg));
+            session.closeAndClearResources(errMsg);
+            return false;
         }
         return true;
     }

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -419,6 +419,10 @@ public class NonBlockingSession implements Session {
             }
         }
 
+        if (this.getSessionXaID() != null && this.xaState == TxState.TX_INITIALIZE_STATE) {
+            this.xaState = TxState.TX_STARTED_STATE;
+        }
+
         RouteResultsetNode[] nodes = rrs.getNodes();
         if (nodes == null || nodes.length == 0 || nodes[0].getName() == null || nodes[0].getName().equals("")) {
             if (rrs.isNeedOptimizer()) {
@@ -434,9 +438,7 @@ public class NonBlockingSession implements Session {
             }
             return;
         }
-        if (this.getSessionXaID() != null && this.xaState == TxState.TX_INITIALIZE_STATE) {
-            this.xaState = TxState.TX_STARTED_STATE;
-        }
+
         if (nodes.length == 1) {
             SingleNodeHandler singleNodeHandler = new SingleNodeHandler(rrs, this);
             setTraceSimpleHandler(singleNodeHandler);


### PR DESCRIPTION
 #1114  when running sysbench oltp test ,XA transaction can't restore after restarting dble，
 #1116  when complex cross join contained in a xa-transaction, the statement commit can't return


Reason:  
  BUG #1114  #1116 
Type:  
  BUG
Influences：  
   fix  #1114  #1116 
