### PR TITLE
#1114 when running sysbench oltp test ,XA transaction can't restore correctly after restarting dble

### DIFF
--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -1018,7 +1018,8 @@ public final class DbleServer {
                     participantLogEntry.getTxState() != TxState.TX_PREPARE_UNCONNECT_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACKING_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACK_FAILED_STATE &&
-                    participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE) {
+                    participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE &&
+                    participantLogEntry.getTxState() != TxState.TX_ENDED_STATE) {
                 continue;
             }
             finished = false;


### PR DESCRIPTION
when running sysbench oltp test ,XA transaction can't restore correctly after restarting dble

Reason:  
  BUG #1114.  
Type:  
  BUG
Influences：  
   fix #1114
