### PR TITLE
#1124 - when buffer is full, dble doesn't reset buffer

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeQueryHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeQueryHandler.java
@@ -396,7 +396,7 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
                 BinaryRowDataPacket binRowDataPk = new BinaryRowDataPacket();
                 binRowDataPk.read(fieldPackets, rowDataPkg);
                 binRowDataPk.setPacketId(rowDataPkg.getPacketId());
-                binRowDataPk.write(byteBuffer, session.getSource(), true);
+                byteBuffer = binRowDataPk.write(byteBuffer, session.getSource(), true);
             } else {
                 byteBuffer = session.getSource().writeToBuffer(row, byteBuffer);
             }


### PR DESCRIPTION
Reason:  
  BUG #1124. 
Type:  
  BUG
Influences：  
  when buffer is full, dble doesn't set index
