### PR TITLE
#1162 - `zk` allow both uppercase and lowercase in the file of sequence_distributed_conf.properties

### DIFF
--- a/src/main/java/com/actiontech/dble/route/sequence/handler/DistributedSequenceHandler.java
+++ b/src/main/java/com/actiontech/dble/route/sequence/handler/DistributedSequenceHandler.java
@@ -109,7 +109,7 @@ public class DistributedSequenceHandler extends LeaderSelectorListenerAdapter im
     public void load() {
         // load sequnce properties
         Properties props = PropertiesUtil.loadProps(SEQUENCE_DB_PROPS);
-        if ("ZK".equals(props.getProperty("INSTANCEID"))) {
+        if ("ZK".equalsIgnoreCase(props.getProperty("INSTANCEID"))) {
             initializeZK(ZkConfig.getInstance().getZkURL());
         } else {
             this.instanceId = Long.parseLong(props.getProperty("INSTANCEID"));


### PR DESCRIPTION
Reason:  
  BUG #1162. 
Type:  
  BUG
Influences：  
  `zk` allow both uppercase and lowercase in the file of sequence_distributed_conf.properties
