### PR TITLE
#1182 Load data will cause exception when the column content only has one '"' at the begining

### DIFF
--- a/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
@@ -120,7 +120,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
         loadData.setFieldTerminatedBy(fieldTerminatedBy);
 
         SQLTextLiteralExpr rawEnclosed = (SQLTextLiteralExpr) statement.getColumnsEnclosedBy();
-        String enclose = rawEnclosed == null ? null : rawEnclosed.getText();
+        String enclose = ((rawEnclosed == null) || rawEnclosed.getText().isEmpty()) ? null : rawEnclosed.getText();
         loadData.setEnclose(enclose);
 
         SQLTextLiteralExpr escapedExpr = (SQLTextLiteralExpr) statement.getColumnsEscaped();
@@ -620,6 +620,8 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
             settings.getFormat().setComment('\0');
             if (loadData.getEnclose() != null) {
                 settings.getFormat().setQuote(loadData.getEnclose().charAt(0));
+            } else {
+                settings.getFormat().setQuote('\0');
             }
             if (loadData.getEscape() != null) {
                 settings.getFormat().setQuoteEscape(loadData.getEscape().charAt(0));
@@ -672,6 +674,8 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
         settings.getFormat().setComment('\0');
         if (loadData.getEnclose() != null) {
             settings.getFormat().setQuote(loadData.getEnclose().charAt(0));
+        } else {
+            settings.getFormat().setQuote('\0');
         }
         settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
 


### PR DESCRIPTION
Reason:  
  BUG https://github.com/actiontech/dble/issues/1182  
Type:  
  BUG  
Influences：  
   fix the bug when the character of enclosed by is ''
