### PR TITLE
#1192 Fail to recover XA Transaction on startup when xa log is not flushed and server is down

### DIFF
--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -1018,6 +1018,7 @@ public final class DbleServer {
                     participantLogEntry.getTxState() != TxState.TX_PREPARE_UNCONNECT_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACKING_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_ROLLBACK_FAILED_STATE &&
+                    participantLogEntry.getTxState() != TxState.TX_ENDED_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_PREPARED_STATE &&
                     participantLogEntry.getTxState() != TxState.TX_PREPARING_STATE) {
                 continue;


### PR DESCRIPTION
…hing xa logs

Reason:  
  BUG #1192
Type:  
  BUG
Influences：  
   fix #1192
