### PR TITLE
#1160 - XACheckHandler#checkXid pass wrong parameters to SQLJob's constructor

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACheckHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACheckHandler.java
@@ -17,6 +17,7 @@ public final class XACheckHandler {
     private static final String[] MYSQL_RECOVER_COLS = new String[]{"data"};
     private final String xid;
     private final String schema;
+    private final String dataNode;
     private final PhysicalDatasource ds;
     private Lock lock;
     private Condition done;
@@ -26,10 +27,11 @@ public final class XACheckHandler {
     private boolean isExistXid = false;
     private boolean isSuccess = true;
 
-    public XACheckHandler(String xid, String schema, PhysicalDatasource ds) {
+    public XACheckHandler(String xid, String schema, String dataNode, PhysicalDatasource ds) {
         this.xid = xid;
         this.ds = ds;
         this.schema = schema;
+        this.dataNode = dataNode;
         this.lock = new ReentrantLock();
         this.done = lock.newCondition();
     }
@@ -41,7 +43,7 @@ public final class XACheckHandler {
             SQLJob sqlJob = new SQLJob(sql, schema, resultHandler, ds);
             sqlJob.run();
         } else {
-            SQLJob sqlJob = new SQLJob(sql, schema, resultHandler, false);
+            SQLJob sqlJob = new SQLJob(sql, dataNode, resultHandler, false);
             sqlJob.run();
         }
         waitDone();
@@ -54,7 +56,7 @@ public final class XACheckHandler {
             SQLJob sqlJob = new SQLJob(sql, schema, resultHandler, ds);
             sqlJob.run();
         } else {
-            SQLJob sqlJob = new SQLJob(sql, schema, resultHandler, false);
+            SQLJob sqlJob = new SQLJob(sql, dataNode, resultHandler, false);
             sqlJob.run();
         }
         waitDone();

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/xa/XACommitNodesHandler.java
@@ -276,7 +276,7 @@ public class XACommitNodesHandler extends AbstractCommitNodesHandler {
                 if (errPacket.getErrNo() == ErrorCode.ER_XAER_NOTA) {
                     RouteResultsetNode rrn = (RouteResultsetNode) mysqlCon.getAttachment();
                     String xid = mysqlCon.getConnXID(session, rrn.getMultiplexNum().longValue());
-                    XACheckHandler handler = new XACheckHandler(xid, mysqlCon.getSchema(), mysqlCon.getPool().getDbPool().getSource());
+                    XACheckHandler handler = new XACheckHandler(xid, mysqlCon.getSchema(), rrn.getName(), mysqlCon.getPool().getDbPool().getSource());
                     // if mysql connection holding xa transaction wasn't released, may result in ER_XAER_NOTA.
                     // so we need check xid here
                     handler.checkXid();


### PR DESCRIPTION
Reason:  
  BUG #1160. 
Type:  
  BUG
Influences：  
  XACheckHandler#checkXid pass wrong parameters to SQLJob's constructor
