### PR TITLE
#1144 - packetId thread safety because connectionClose execute before errorResponse

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
@@ -158,7 +158,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
         if (syncFinished) {
             session.releaseConnectionIfSafe(conn, false);
         } else {
-            ((MySQLConnection) conn).close();
+            conn.closeWithoutRsp("unfinished sync");
             session.getTargetMap().remove(conn.getAttachment());
         }
         source.setTxInterrupt(errMsg);


### PR DESCRIPTION
Reason:  
  BUG #1144. 
Type:  
  BUG
Influences：  
  packetId thread safety because connectionClose execute before errorResponse
