### PR TITLE
DateNode Idle Check Thread failed to fill empty datasource when dataHost's minCon is less than database size

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDBPool.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDBPool.java
@@ -358,7 +358,9 @@ public class PhysicalDBPool {
         int initSize = ds.getConfig().getMinCon();
         if (initSize < this.schemas.length + 1) {
             initSize = this.schemas.length + 1;
-            LOGGER.warn("minCon size is less than (the count of schema +1), so dble will create at least 1 conn for every schema and an empty schema conn");
+            LOGGER.warn("minCon size is less than (the count of schema +1), so dble will create at least 1 conn for every schema and an empty schema conn, " +
+                    "minCon size before:{}, now:{}", ds.getConfig().getMinCon(), initSize);
+            ds.getConfig().setMinCon(initSize);
         }
 
         if (ds.getConfig().getMaxCon() < initSize) {

--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
@@ -185,13 +185,13 @@ public abstract class PhysicalDatasource {
         //the following is about the idle connection number control
         int idleCons = getIdleCount();
         int totalCount = this.getTotalConCount();
-        int createCount = (hostConfig.getMinCon() - idleCons) / 3;
+        int createCount = (config.getMinCon() - idleCons) / 3;
 
         // create if idle too little
         if ((createCount > 0) && totalCount < size) {
             createByIdleLittle(idleCons, createCount);
-        } else if (idleCons > hostConfig.getMinCon()) {
-            closeByIdleMany(idleCons - hostConfig.getMinCon(), idleCons);
+        } else if (idleCons > config.getMinCon()) {
+            closeByIdleMany(idleCons - config.getMinCon(), idleCons);
         }
     }
 


### PR DESCRIPTION
Reason:  
  BUG #1125. 
Type:  
  BUG  
Influences：  
  DateNode Idle Check Thread failed to fill empty datasource when dataHost's minCon is less than database size
