### PR TITLE
#1218 - dble don't limit the number of user frontend connection by default

### DIFF
--- a/docker-images/quick-start/server.xml
+++ b/docker-images/quick-start/server.xml
@@ -19,9 +19,9 @@
         <!--<property name="bindIp">0.0.0.0</property>-->
         <property name="serverPort">8066</property>
         <property name="managerPort">9066</property>
-        <!--<property name="maxCon">1024</property> -->
-        <!-- <property name="processors">4</property>-->
-        <!-- <property name="backendProcessors">12</property>-->
+        <!--<property name="maxCon">0</property> -->
+        <!--<property name="processors">4</property>-->
+        <!--<property name="backendProcessors">12</property>-->
         <!--<property name="processorExecutor">4</property> -->
         <!--<property name="backendProcessorExecutor">12</property> -->
         <!--<property name="complexExecutor">8</property> -->

--- a/src/main/java/com/actiontech/dble/config/model/SystemConfig.java
+++ b/src/main/java/com/actiontech/dble/config/model/SystemConfig.java
@@ -49,7 +49,7 @@ public final class SystemConfig {
     private int serverBacklog = 2048;
     private int serverNodeId = 1;
     private long showBinlogStatusTimeout = 60 * 1000;
-    private int maxCon = 1024;
+    private int maxCon = 0;
     //option
     private int useCompression = 0;
     private int usingAIO = 0;

--- a/src/main/java/com/actiontech/dble/net/FrontendUserManager.java
+++ b/src/main/java/com/actiontech/dble/net/FrontendUserManager.java
@@ -70,10 +70,9 @@ public class FrontendUserManager {
                 }
             }
             if (!isManager) {
-                if (serverMaxConnection <= serverConnection) {
+                if (serverMaxConnection > 0 && serverMaxConnection <= serverConnection) {
                     return SERVER_MAX;
                 }
-
                 serverConnection++;
             }
             userConnectionMap.put(user, ++userConnection);

--- a/src/main/resources/server_template.xml
+++ b/src/main/resources/server_template.xml
@@ -19,9 +19,9 @@
         <!--<property name="bindIp">0.0.0.0</property>-->
         <!-- property name="serverPort">8066</property> -->
         <!--<property name="managerPort">9066</property> -->
-        <!--<property name="maxCon">1024</property> -->
-        <!-- <property name="processors">4</property>-->
-        <!-- <property name="backendProcessors">12</property>-->
+        <!--<property name="maxCon">0</property> -->
+        <!--<property name="processors">4</property>-->
+        <!--<property name="backendProcessors">12</property>-->
         <!--<property name="processorExecutor">4</property> -->
         <!--<property name="backendProcessorExecutor">12</property> -->
         <!--<property name="complexExecutor">8</property> -->


### PR DESCRIPTION
Reason:  
  Improve #1218.  
Type:  
  Improve  
Influences：  
  dble don't limit the number of user frontend connection by default
