### PR TITLE
replace method close to closeWithoutRsp

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/FetchStoreNodeOfChildTableHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/FetchStoreNodeOfChildTableHandler.java
@@ -172,7 +172,7 @@ public class FetchStoreNodeOfChildTableHandler implements ResponseHandler {
                 fatalRRSSet.add(((RouteResultsetNode) conn.getAttachment()));
                 session.getTargetMap().remove(node);
             }
-            conn.close("set status error");
+            conn.closeWithoutRsp("unfinished sync");
         }
         coutResult((MySQLConnection) conn);
     }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/LockTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/LockTablesHandler.java
@@ -8,7 +8,6 @@ package com.actiontech.dble.backend.mysql.nio.handler;
 import com.actiontech.dble.DbleServer;
 import com.actiontech.dble.backend.BackendConnection;
 import com.actiontech.dble.backend.datasource.PhysicalDBNode;
-import com.actiontech.dble.backend.mysql.nio.MySQLConnection;
 import com.actiontech.dble.net.mysql.ErrorPacket;
 import com.actiontech.dble.net.mysql.FieldPacket;
 import com.actiontech.dble.net.mysql.OkPacket;
@@ -76,7 +75,7 @@ public class LockTablesHandler extends MultiNodeHandler {
         if (executeResponse) {
             session.releaseConnectionIfSafe(conn, false);
         } else {
-            ((MySQLConnection) conn).close();
+            conn.closeWithoutRsp("unfinished sync");
             session.getTargetMap().remove(conn.getAttachment());
         }
         ErrorPacket errPacket = new ErrorPacket();

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/UnLockTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/UnLockTablesHandler.java
@@ -6,7 +6,6 @@
 package com.actiontech.dble.backend.mysql.nio.handler;
 
 import com.actiontech.dble.backend.BackendConnection;
-import com.actiontech.dble.backend.mysql.nio.MySQLConnection;
 import com.actiontech.dble.net.mysql.ErrorPacket;
 import com.actiontech.dble.net.mysql.FieldPacket;
 import com.actiontech.dble.net.mysql.OkPacket;
@@ -84,7 +83,7 @@ public class UnLockTablesHandler extends MultiNodeHandler implements ResponseHan
         if (executeResponse) {
             session.releaseConnectionIfSafe(conn, false);
         } else {
-            ((MySQLConnection) conn).close();
+            conn.closeWithoutRsp("unfinished sync");
             session.getTargetMap().remove(conn.getAttachment());
         }
         ErrorPacket errPacket = new ErrorPacket();

--- a/src/main/java/com/actiontech/dble/route/sequence/handler/FetchMySQLSequenceHandler.java
+++ b/src/main/java/com/actiontech/dble/route/sequence/handler/FetchMySQLSequenceHandler.java
@@ -81,7 +81,7 @@ public class FetchMySQLSequenceHandler implements ResponseHandler {
         if (executeResponse) {
             conn.release();
         } else {
-            ((MySQLConnection) conn).close();
+            conn.closeWithoutRsp("unfinished sync");
         }
 
     }

--- a/src/main/java/com/actiontech/dble/sqlengine/MultiSQLJob.java
+++ b/src/main/java/com/actiontech/dble/sqlengine/MultiSQLJob.java
@@ -122,7 +122,7 @@ public class MultiSQLJob implements ResponseHandler, Runnable {
         if (conn.syncAndExecute()) {
             conn.release();
         } else {
-            ((MySQLConnection) conn).close();
+            conn.closeWithoutRsp("unfinished sync");
         }
         doFinished(true);
     }

--- a/src/main/java/com/actiontech/dble/sqlengine/SQLJob.java
+++ b/src/main/java/com/actiontech/dble/sqlengine/SQLJob.java
@@ -124,7 +124,7 @@ public class SQLJob implements ResponseHandler, Runnable {
 
         LOGGER.info(errMsg);
         if (!conn.syncAndExecute()) {
-            ((MySQLConnection) conn).close();
+            conn.closeWithoutRsp("unfinished sync");
             doFinished(true);
             return;
         }


### PR DESCRIPTION
Reason:  
  BUG .  
Type:  
  BUG
Influences：  
  replace method close to closeWithoutRsp in case of multi statement failure before statement that user need to execute
