### PR TITLE
Inner 220 when use ucore cluster,default alertSender should be UcoreA…

### DIFF
--- a/src/main/java/com/actiontech/dble/alarm/AlertSender.java
+++ b/src/main/java/com/actiontech/dble/alarm/AlertSender.java
@@ -63,10 +63,11 @@ public class AlertSender implements Runnable {
         AlertGeneralConfig confg = AlertGeneralConfig.getInstance();
         confg.initAlertConfig();
         alert = confg.customizedAlert();
-        if (DEFAULT_ALERT != alert &&
+        if (DEFAULT_ALERT == alert &&
                 DbleServer.getInstance().isUseGeneralCluster() &&
                 (ClusterController.CONFIG_MODE_UCORE.equals(ClusterGeneralConfig.getInstance().getClusterType()) ||
                         ClusterController.CONFIG_MODE_USHARD.equals(ClusterGeneralConfig.getInstance().getClusterType()))) {
+            LOGGER.info("Ucore cluster,use default alert UcoreAlert");
             alert = new UcoreAlert();
         }
     }


### PR DESCRIPTION
Reason:  
  BUG  Inner 220  
Type:  
  BUG  
Influences：  
   When use ucore/ushard cluster,default alertSender should be UcoreAlert
