### PR TITLE
#1250 - ignore enclose char when using load data

### DIFF
--- a/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
@@ -484,9 +484,12 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
 
     private String joinField(String[] src, LoadData loaddata) {
         StringBuilder sb = new StringBuilder();
+        String enclose = loaddata.getEnclose() == null ? "" : loaddata.getEnclose();
         for (int i = 0, srcLength = src.length; i < srcLength; i++) {
             String s = src[i] != null ? src[i] : "";
+            sb.append(enclose);
             sb.append(s);
+            sb.append(enclose);
             if (i != srcLength - 1) {
                 sb.append(loaddata.getFieldTerminatedBy());
             }


### PR DESCRIPTION
Reason:  
  BUG #1250.
Type:  
  BUG
Influences：  
  ignore enclose char when using load data
