### PR TITLE
#1342 - unify column name that contains connection id in manager cmd and log

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/MySQLConnection.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/MySQLConnection.java
@@ -838,7 +838,7 @@ public class MySQLConnection extends AbstractConnection implements
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();
-        result.append("MySQLConnection [id=");
+        result.append("MySQLConnection [backendId=");
         result.append(id);
         result.append(", lastTime=");
         result.append(lastTime);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowBackend.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowBackend.java
@@ -40,7 +40,7 @@ public final class ShowBackend {
         HEADER.setPacketId(++packetId);
         FIELDS[i] = PacketUtil.getField("processor", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
-        FIELDS[i] = PacketUtil.getField("ID", Fields.FIELD_TYPE_LONG);
+        FIELDS[i] = PacketUtil.getField("BACKEND_ID", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);
         FIELDS[i] = PacketUtil.getField("MYSQLID", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowBackendOld.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowBackendOld.java
@@ -40,7 +40,7 @@ public final class ShowBackendOld {
         int i = 0;
         byte packetId = 0;
         HEADER.setPacketId(++packetId);
-        FIELDS[i] = PacketUtil.getField("ID", Fields.FIELD_TYPE_LONG);
+        FIELDS[i] = PacketUtil.getField("BACKEND_ID", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);
         FIELDS[i] = PacketUtil.getField("MYSQLID", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowConnection.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowConnection.java
@@ -47,7 +47,7 @@ public final class ShowConnection {
                 Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("ID", Fields.FIELD_TYPE_LONG);
+        FIELDS[i] = PacketUtil.getField("FRONT_ID", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("HOST", Fields.FIELD_TYPE_VAR_STRING);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowConnectionSQL.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowConnectionSQL.java
@@ -39,7 +39,7 @@ public final class ShowConnectionSQL {
         byte packetId = 0;
         HEADER.setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("ID", Fields.FIELD_TYPE_LONG);
+        FIELDS[i] = PacketUtil.getField("FRONT_ID", Fields.FIELD_TYPE_LONG);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("HOST", Fields.FIELD_TYPE_VAR_STRING);

--- a/src/main/java/com/actiontech/dble/manager/response/ShowSession.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowSession.java
@@ -42,14 +42,14 @@ public final class ShowSession {
         byte packetId = 0;
         HEADER.setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("SESSION", Fields.FIELD_TYPE_VARCHAR);
+        FIELDS[i] = PacketUtil.getField("FRONT_ID", Fields.FIELD_TYPE_VARCHAR);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("DN_COUNT", Fields.FIELD_TYPE_VARCHAR);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("DN_LIST", Fields.FIELD_TYPE_VARCHAR);
-        FIELDS[i++].setPacketId(++packetId);
+        FIELDS[i].setPacketId(++packetId);
         EOF.setPacketId(++packetId);
     }
 

--- a/src/main/java/com/actiontech/dble/manager/response/ShowXASession.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ShowXASession.java
@@ -39,7 +39,7 @@ public final class ShowXASession {
         byte packetId = 0;
         HEADER.setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("SESSION", Fields.FIELD_TYPE_VARCHAR);
+        FIELDS[i] = PacketUtil.getField("FRONT_ID", Fields.FIELD_TYPE_VARCHAR);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("XA_ID", Fields.FIELD_TYPE_VARCHAR);

--- a/src/main/java/com/actiontech/dble/net/FrontendConnection.java
+++ b/src/main/java/com/actiontech/dble/net/FrontendConnection.java
@@ -543,7 +543,7 @@ public abstract class FrontendConnection extends AbstractConnection {
     public String toString() {
         return "[thread=" +
                 Thread.currentThread().getName() + ",class=" +
-                getClass().getSimpleName() + ",id=" + id +
+                getClass().getSimpleName() + ",frontId=" + id +
                 ",host=" + host + ",port=" + port +
                 ",schema=" + schema + ']';
     }

--- a/src/main/java/com/actiontech/dble/server/ServerConnection.java
+++ b/src/main/java/com/actiontech/dble/server/ServerConnection.java
@@ -524,7 +524,7 @@ public class ServerConnection extends FrontendConnection {
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();
-        result.append("ServerConnection [id=");
+        result.append("ServerConnection [frontId=");
         result.append(id);
         result.append(", schema=");
         result.append(schema);


### PR DESCRIPTION
Reason:  
  Improve #1342 .  
Type:  
  Improve  
Influences：  
  unify column name that contains connection id in manager cmd and log
