### PR TITLE
Let ClusterOffLineListener.java log call stack when it meets exception in master

### DIFF
--- a/src/main/java/com/actiontech/dble/cluster/listener/ClusterOffLineListener.java
+++ b/src/main/java/com/actiontech/dble/cluster/listener/ClusterOffLineListener.java
@@ -70,7 +70,7 @@ public class ClusterOffLineListener implements Runnable {
                 }
             }
         } catch (Exception e) {
-            LOGGER.warn(" server offline binlog status check error");
+            LOGGER.warn(" server offline binlog status check error: ", e);
         }
     }
 
@@ -92,7 +92,7 @@ public class ClusterOffLineListener implements Runnable {
             }
 
         } catch (Exception e) {
-            LOGGER.warn(" server offline binlog status check error");
+            LOGGER.warn(" server offline binlog status check error: ", e);
         }
     }
 
@@ -113,7 +113,7 @@ public class ClusterOffLineListener implements Runnable {
                     }
                     continue;
                 }
-                //logger.debug("the index of the single key "+path+" is "+index);
+                //LOGGER.debug("the index of the single key "+path+" is "+index);
                 Map<String, String> newMap = new HashMap<>();
                 for (int i = 0; i < output.getKeysCount(); i++) {
                     newMap.put(output.getKeys(i), output.getValues(i));
@@ -137,7 +137,7 @@ public class ClusterOffLineListener implements Runnable {
                 onlineMap = newMap;
                 index = output.getIndex();
             } catch (Exception e) {
-                LOGGER.warn("error in offline listener :", e);
+                LOGGER.warn("error in offline listener: ", e);
             }
         }
     }
@@ -153,7 +153,7 @@ public class ClusterOffLineListener implements Runnable {
             }
             return true;
         } catch (Exception e) {
-            LOGGER.warn("rewrite server online status failed", e);
+            LOGGER.warn("rewrite server online status failed: ", e);
             //alert
             return false;
         }


### PR DESCRIPTION
log call stack when it catch an exception

Reason:  
  It is IMPOSSIBLE to analyze because of the absence of call stack in dble.log .
Type:  
  Improve  
Influences：  
  If there is an exception, the call stack will be print in dble.log.