### PR TITLE
#1212 delete old zk key so that restart dble in zk would not throw error

### DIFF
--- a/src/main/java/com/actiontech/dble/meta/ProxyMetaManager.java
+++ b/src/main/java/com/actiontech/dble/meta/ProxyMetaManager.java
@@ -340,6 +340,12 @@ public class ProxyMetaManager {
         }
 
         initMeta(config);
+        //try to delete online
+        if (ZKUtils.getConnection().checkExists().forPath(KVPathUtil.getOnlinePath()
+                + KVPathUtil.SEPARATOR + ZkConfig.getInstance().getValue(ClusterParamCfg.CLUSTER_CFG_MYID)) != null) {
+            ZKUtils.getConnection().delete().forPath(KVPathUtil.getOnlinePath()
+                    + KVPathUtil.SEPARATOR + ZkConfig.getInstance().getValue(ClusterParamCfg.CLUSTER_CFG_MYID));
+        }
         // online
         ZKUtils.createTempNode(KVPathUtil.getOnlinePath(), ZkConfig.getInstance().getValue(ClusterParamCfg.CLUSTER_CFG_MYID));
         //add watcher


### PR DESCRIPTION
Reason:  
  BUG #1212  
Type:  
  BUG  
Influences：  
   delete old zk key so that restart dble in zk would not throw error
