### PR TITLE
avoid dead loops in Timer executor when checking global table

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLConsistencyHelper.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLConsistencyHelper.java
@@ -46,7 +46,7 @@ public class MySQLConsistencyHelper implements SQLQueryResultListener<SQLQueryRe
 
     @Override
     public void onResult(SQLQueryResult<Map<String, String>> result) {
-        LOGGER.debug("resultresultresultresult:" + JSON.toJSONString(result));
+        LOGGER.debug("result:" + JSON.toJSONString(result));
         Map<String, String> rowMap = null;
         String count = null;
         String innerCol = null;
@@ -71,7 +71,7 @@ public class MySQLConsistencyHelper implements SQLQueryResultListener<SQLQueryRe
                         //ignore error
                     }
                     this.retryTime.decrementAndGet();
-                    this.sqlJob.run();
+                    ((SQLJob) this.sqlJob.clone()).run();
                     return;
                 }
                 heartbeat.setResult(result);
@@ -85,7 +85,7 @@ public class MySQLConsistencyHelper implements SQLQueryResultListener<SQLQueryRe
                     //ignore error
                 }
                 this.retryTime.decrementAndGet();
-                this.sqlJob.run();
+                ((SQLJob) this.sqlJob.clone()).run();
                 return;
             }
             heartbeat.setResult(result);

--- a/src/main/java/com/actiontech/dble/sqlengine/SQLJob.java
+++ b/src/main/java/com/actiontech/dble/sqlengine/SQLJob.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author wuzhih
  */
-public class SQLJob implements ResponseHandler, Runnable {
+public class SQLJob implements ResponseHandler, Runnable, Cloneable {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(SQLJob.class);
 
@@ -196,6 +196,19 @@ public class SQLJob implements ResponseHandler, Runnable {
                 dataNode + ",schema=" +
                 schema + ",sql=" + sql + ",  jobHandler=" +
                 jobHandler + "]";
+    }
+
+    @Override
+    public Object clone() {
+        SQLJob newSqlJob = null;
+        try {
+            newSqlJob = (SQLJob) super.clone();
+            newSqlJob.finished.set(false);
+        } catch (CloneNotSupportedException e) {
+            // ignore
+            LOGGER.warn("SQLJob CloneNotSupportedException, impossible");
+        }
+        return newSqlJob;
     }
 
 }


### PR DESCRIPTION
Reason:  
  BUG #1286. 
Type:  
  BUG
Influences：  
  avoid dead loops in Timer executor when checking global table
