### PR TITLE
fix #1368

### DIFF
--- a/src/main/assembly/bin/encrypt.sh
+++ b/src/main/assembly/bin/encrypt.sh
@@ -33,4 +33,6 @@ PASSWORD=${input/password=/""}
 RUN_CMD="$CORE_JAVA_HOME/bin/java -cp $APP_HOME/lib/dble*.jar com.actiontech.dble.util.DecryptUtil $PASSWORD"
 echo "$CORE_JAVA_HOME/bin/java -cp $APP_HOME/lib/dble*.jar com.actiontech.dble.util.DecryptUtil password=******"
 eval $RUN_CMD
+EXIT_STATUS=$?
+exit $EXIT_STATUS
 #==============================================================================


### PR DESCRIPTION
encrypt.sh exits with the exit status of the java program

Reason:  
  BUG #1368 
Type:  
  BUG
Influences：  
   same as brief above