### PR TITLE
can't lock table if user did nothing in transaction

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalCommitNodesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/normal/NormalCommitNodesHandler.java
@@ -19,6 +19,14 @@ public class NormalCommitNodesHandler extends AbstractCommitNodesHandler {
     @Override
     public void commit() {
         final int initCount = session.getTargetCount();
+        if (initCount <= 0) {
+            if (implictCommitHandler == null && sendData == null) {
+                sendData = session.getOkByteArray();
+            }
+            cleanAndFeedback();
+            return;
+        }
+
         lock.lock();
         try {
             reset(initCount);

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -630,14 +630,6 @@ public class NonBlockingSession implements Session {
     }
 
     public void commit() {
-        final int initCount = target.size();
-        if (initCount <= 0) {
-            clearResources(false);
-            ByteBuffer buffer = source.allocate();
-            buffer = source.writeToBuffer(OkPacket.OK, buffer);
-            source.write(buffer);
-            return;
-        }
         checkBackupStatus();
         resetCommitNodesHandler();
         commitHandler.commit();


### PR DESCRIPTION
Reason:  
  BUG #1380.
Type:  
  BUG
Influences：  
  can't lock table if user did nothing in transaction
