### PR TITLE
Inner-230 reload may block because of thread safe problem

### DIFF
--- a/src/main/java/com/actiontech/dble/cluster/AbstractClusterSender.java
+++ b/src/main/java/com/actiontech/dble/cluster/AbstractClusterSender.java
@@ -41,6 +41,12 @@ public abstract class AbstractClusterSender implements ClusterSender {
         checkOnline(expectedMap, currentMap);
         List<KvBean> responseList = ClusterHelper.getKVPath(path);
         boolean flag = false;
+        if (expectedMap.size() == 0) {
+            if (errorMsg != null) {
+                errorMsg.append("All online key droped, other instance config may out of sync, try again");
+            }
+            return true;
+        }
         for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
             flag = false;
             for (KvBean kvBean : responseList) {

--- a/src/main/java/com/actiontech/dble/cluster/listener/ClusterOffLineListener.java
+++ b/src/main/java/com/actiontech/dble/cluster/listener/ClusterOffLineListener.java
@@ -24,8 +24,8 @@ import com.actiontech.dble.singleton.OnlineStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.actiontech.dble.cluster.ClusterPathUtil.SEPARATOR;
 
@@ -35,12 +35,12 @@ import static com.actiontech.dble.cluster.ClusterPathUtil.SEPARATOR;
 public class ClusterOffLineListener implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterOffLineListener.class);
-    private volatile Map<String, String> onlineMap = new HashMap<>();
+    private volatile Map<String, String> onlineMap = new ConcurrentHashMap<>();
     private long index = 0;
 
 
     public Map<String, String> copyOnlineMap() {
-        return new HashMap<>(onlineMap);
+        return new ConcurrentHashMap<>(onlineMap);
     }
 
     private void checkDDLAndRelease(String serverId) {
@@ -116,7 +116,7 @@ public class ClusterOffLineListener implements Runnable {
                     continue;
                 }
                 //LOGGER.debug("the index of the single key "+path+" is "+index);
-                Map<String, String> newMap = new HashMap<>();
+                Map<String, String> newMap = new ConcurrentHashMap<>();
                 for (int i = 0; i < output.getKeysCount(); i++) {
                     newMap.put(output.getKeys(i), output.getValues(i));
                 }


### PR DESCRIPTION
Reason:  
  BUG #Inner 230
Type:  
  BUG
Influences：  
   Use a ConcurrentHashMap to replace HashMap
   Add redundancy safe check for loop
