### PR TITLE
upgrade dependency of univocity-parsers, due to load data terminated char

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>com.univocity</groupId>
             <artifactId>univocity-parsers</artifactId>
-            <version>2.2.1</version>
+            <version>2.8.3</version>
             <type>jar</type>
         </dependency>
 

--- a/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
@@ -673,7 +673,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
         settings.setMaxColumns(DEFAULT_MAX_COLUMNS);
         settings.setMaxCharsPerColumn(systemConfig.getMaxCharsPerColumn());
         settings.getFormat().setLineSeparator(loadData.getLineTerminatedBy());
-        settings.getFormat().setDelimiter(loadData.getFieldTerminatedBy().charAt(0));
+        settings.getFormat().setDelimiter(loadData.getFieldTerminatedBy());
         settings.getFormat().setComment('\0');
         if (loadData.getEnclose() != null) {
             settings.getFormat().setQuote(loadData.getEnclose().charAt(0));


### PR DESCRIPTION
Reason:  
  BUG #1456
Type:  
  BUG
Influences：  
  load data terminated char is |||
