### PR TITLE
#1528 disable dataHost may cause connection control error

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
@@ -390,10 +390,6 @@ public abstract class PhysicalDatasource {
                 AlertUtil.alert(AlarmCode.REACH_MAX_CON, Alert.AlertLevel.WARN, maxConError, "dble", this.getConfig().getId(), labels);
                 ToResolveContainer.REACH_MAX_CON.add(this.getHostConfig().getName() + "-" + this.getConfig().getHostName());
                 throw new IOException(maxConError);
-            } else if (this.disabled.get()) {
-                String disableError = "the Datasource is turned into disabled " + this.getHostConfig().getName() + "-" + this.getConfig().getHostName();
-                LOGGER.warn(disableError);
-                throw new IOException(disableError);
             } else { // create connection
                 if (ToResolveContainer.REACH_MAX_CON.contains(this.getHostConfig().getName() + "-" + this.getConfig().getHostName())) {
                     Map<String, String> labels = AlertUtil.genSingleLabel("data_host", this.getHostConfig().getName() + "-" + this.getConfig().getHostName());
@@ -418,10 +414,6 @@ public abstract class PhysicalDatasource {
                 AlertUtil.alert(AlarmCode.REACH_MAX_CON, Alert.AlertLevel.WARN, maxConError, "dble", this.getConfig().getId(), labels);
                 ToResolveContainer.REACH_MAX_CON.add(this.getHostConfig().getName() + "-" + this.getConfig().getHostName());
                 throw new IOException(maxConError);
-            } else if (this.disabled.get()) {
-                String disableError = "the Datasource is turned into disabled " + this.getHostConfig().getName() + "-" + this.getConfig().getHostName();
-                LOGGER.warn(disableError);
-                throw new IOException(disableError);
             } else { // create connection
                 if (ToResolveContainer.REACH_MAX_CON.contains(this.getHostConfig().getName() + "-" + this.getConfig().getHostName())) {
                     Map<String, String> labels = AlertUtil.genSingleLabel("data_host", this.getHostConfig().getName() + "-" + this.getConfig().getHostName());

--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDatasource.java
@@ -360,6 +360,7 @@ public abstract class PhysicalDatasource {
                         public void connectionAcquired(BackendConnection conn) {
                             if (disabled.get()) {
                                 handler.connectionError(new IOException("dataSource disabled"), conn);
+                                conn.close("disabled dataHost");
                             } else if (mustWrite && isReadNode()) {
                                 handler.connectionError(new IOException("writeSrouce switched"), conn);
                             } else {
@@ -383,7 +384,9 @@ public abstract class PhysicalDatasource {
         if (con != null) {
             takeCon(con, handler, attachment, schema);
         } else {
-            if (!this.createNewCount()) {
+            if (disabled.get()) {
+                throw new IOException("the dataSource is disabled [" + this.name + "]");
+            } else if (!this.createNewCount()) {
                 String maxConError = "the max active Connections size can not be max than maxCon for data host[" + this.getHostConfig().getName() + "." + this.getName() + "]";
                 LOGGER.warn(maxConError);
                 Map<String, String> labels = AlertUtil.genSingleLabel("data_host", this.getHostConfig().getName() + "-" + this.getConfig().getHostName());
@@ -407,7 +410,9 @@ public abstract class PhysicalDatasource {
     public BackendConnection getConnection(String schema, boolean autocommit, final Object attachment) throws IOException {
         BackendConnection con = this.conMap.tryTakeCon(schema, autocommit);
         if (con == null) {
-            if (!this.createNewCount()) {
+            if (disabled.get()) {
+                throw new IOException("the dataSource is disabled [" + this.name + "]");
+            } else if (!this.createNewCount()) {
                 String maxConError = "the max active Connections size can not be max than maxCon data host[" + this.getHostConfig().getName() + "." + this.getName() + "]";
                 LOGGER.warn(maxConError);
                 Map<String, String> labels = AlertUtil.genSingleLabel("data_host", this.getHostConfig().getName() + "-" + this.getConfig().getHostName());


### PR DESCRIPTION
Reason:  
  BUG #1528 
Type:  
  BUG  
Influences：  
   delete a double check of dataHost disable status, let it check at connection create call back