### PR TITLE
remove security_alert log4j 1.2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,11 +164,6 @@
             <version>2.7</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-        <dependency>
             <groupId>com.univocity</groupId>
             <artifactId>univocity-parsers</artifactId>
             <version>2.8.3</version>

--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -224,7 +224,7 @@ public final class DbleServer {
 
         // start transaction SQL log
         if (config.getSystem().getRecordTxn() == 1) {
-            txnLogProcessor = new TxnLogProcessor(BufferPoolManager.getBufferPool());
+            txnLogProcessor = new TxnLogProcessor();
             txnLogProcessor.setName("TxnLogProcessor");
             txnLogProcessor.start();
         }

--- a/src/main/java/com/actiontech/dble/log/transaction/TxnLogProcessor.java
+++ b/src/main/java/com/actiontech/dble/log/transaction/TxnLogProcessor.java
@@ -6,13 +6,11 @@
 package com.actiontech.dble.log.transaction;
 
 import com.actiontech.dble.DbleServer;
-import com.actiontech.dble.buffer.BufferPool;
 import com.actiontech.dble.config.ServerConfig;
 import com.actiontech.dble.config.model.SystemConfig;
 import com.actiontech.dble.log.DailyRotateLogStore;
 import com.actiontech.dble.server.ServerConnection;
 import com.actiontech.dble.util.TimeUtil;
-import org.apache.log4j.helpers.ISO8601DateFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,6 +18,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -30,8 +29,8 @@ public class TxnLogProcessor extends Thread {
     private BlockingQueue<TxnBinaryLog> queue;
     private DailyRotateLogStore store;
 
-    public TxnLogProcessor(BufferPool bufferPool) {
-        this.dateFormat = new ISO8601DateFormat();
+    public TxnLogProcessor() {
+        this.dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
         this.queue = new LinkedBlockingQueue<>(256);
         ServerConfig config = DbleServer.getInstance().getConfig();
         SystemConfig systemConfig = config.getSystem();


### PR DESCRIPTION
Reason:  
  security_alert [CVE-2019-17571](https://github.com/advisories/GHSA-2qrg-x229-3v8q)
Type:  
  security_alert
Influences：  
   fix security_alert
