### PR TITLE
change abstract function into public so it can be used by customized …

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/check/AbstractConsistencyChecker.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/check/AbstractConsistencyChecker.java
@@ -101,13 +101,13 @@ public abstract class AbstractConsistencyChecker implements SQLQueryResultListen
         this.handler = handler;
     }
 
-    abstract String[] getFetchCols();
+    public abstract String[] getFetchCols();
 
-    abstract String getCountSQL(String dbName, String tName);
+    public abstract String getCountSQL(String dbName, String tName);
 
-    abstract boolean resultEquals(SQLQueryResult<List<Map<String, String>>> or, SQLQueryResult<List<Map<String, String>>> cr);
+    public abstract boolean resultEquals(SQLQueryResult<List<Map<String, String>>> or, SQLQueryResult<List<Map<String, String>>> cr);
 
-    abstract void failResponse(List<SQLQueryResult<List<Map<String, String>>>> res);
+    public abstract void failResponse(List<SQLQueryResult<List<Map<String, String>>>> res);
 
-    abstract void resultResponse(List<SQLQueryResult<List<Map<String, String>>>> elist);
+    public abstract void resultResponse(List<SQLQueryResult<List<Map<String, String>>>> elist);
 }

--- a/src/main/java/com/actiontech/dble/backend/datasource/check/CheckSumChecker.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/check/CheckSumChecker.java
@@ -22,17 +22,17 @@ public class CheckSumChecker extends AbstractConsistencyChecker {
     }
 
     @Override
-    String[] getFetchCols() {
+    public String[] getFetchCols() {
         return new String[]{"Checksum"};
     }
 
     @Override
-    String getCountSQL(String dbName, String tName) {
+    public String getCountSQL(String dbName, String tName) {
         return "checksum table " + tName;
     }
 
     @Override
-    boolean resultEquals(SQLQueryResult<List<Map<String, String>>> or, SQLQueryResult<List<Map<String, String>>> cr) {
+    public boolean resultEquals(SQLQueryResult<List<Map<String, String>>> or, SQLQueryResult<List<Map<String, String>>> cr) {
         Map<String, String> oresult = or.getResult().get(0);
         Map<String, String> cresult = cr.getResult().get(0);
         return (oresult.get("Checksum") == null && cresult.get("Checksum") == null) ||
@@ -41,7 +41,7 @@ public class CheckSumChecker extends AbstractConsistencyChecker {
     }
 
     @Override
-    void failResponse(List<SQLQueryResult<List<Map<String, String>>>> res) {
+    public void failResponse(List<SQLQueryResult<List<Map<String, String>>>> res) {
         String tableId = schema + "." + tableName;
         String errorMsg = "Global Consistency Check fail for table :" + schema + "-" + tableName;
         LOGGER.warn(errorMsg);
@@ -53,7 +53,7 @@ public class CheckSumChecker extends AbstractConsistencyChecker {
     }
 
     @Override
-    void resultResponse(List<SQLQueryResult<List<Map<String, String>>>> elist) {
+    public void resultResponse(List<SQLQueryResult<List<Map<String, String>>>> elist) {
         String tableId = schema + "." + tableName;
 
         if (elist.size() == 0) {

--- a/src/main/java/com/actiontech/dble/backend/datasource/check/CountChecker.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/check/CountChecker.java
@@ -19,17 +19,17 @@ public class CountChecker extends AbstractConsistencyChecker {
     private static final Logger LOGGER = LoggerFactory.getLogger(CountChecker.class);
 
     @Override
-    String[] getFetchCols() {
+    public String[] getFetchCols() {
         return new String[]{"cr"};
     }
 
     @Override
-    String getCountSQL(String dbName, String tName) {
+    public String getCountSQL(String dbName, String tName) {
         return "select count(1) as cr from " + tName;
     }
 
     @Override
-    boolean resultEquals(SQLQueryResult<List<Map<String, String>>> or, SQLQueryResult<List<Map<String, String>>> cr) {
+    public boolean resultEquals(SQLQueryResult<List<Map<String, String>>> or, SQLQueryResult<List<Map<String, String>>> cr) {
         Map<String, String> oresult = or.getResult().get(0);
         Map<String, String> cresult = cr.getResult().get(0);
         return (oresult.get("cr") == null && cresult.get("cr") == null) ||
@@ -38,7 +38,7 @@ public class CountChecker extends AbstractConsistencyChecker {
     }
 
     @Override
-    void failResponse(List<SQLQueryResult<List<Map<String, String>>>> res) {
+    public void failResponse(List<SQLQueryResult<List<Map<String, String>>>> res) {
         String tableId = schema + "." + tableName;
         String errorMsg = "Global Consistency Check fail for table :" + schema + "-" + tableName;
         LOGGER.warn(errorMsg);
@@ -50,7 +50,7 @@ public class CountChecker extends AbstractConsistencyChecker {
     }
 
     @Override
-    void resultResponse(List<SQLQueryResult<List<Map<String, String>>>> elist) {
+    public void resultResponse(List<SQLQueryResult<List<Map<String, String>>>> elist) {
         String tableId = schema + "." + tableName;
 
         if (elist.size() == 0) {


### PR DESCRIPTION
…check

Reason:  
  BUG #1558  
Type:  
  BUG
Influences：  
  change abstract function into public so it can be used by customized check
