### PR TITLE
fix #1680 on master

### DIFF
--- a/src/test/java/com/actiontech/dble/cluster/xmltoKv/XmlServerLoaderTest.java
+++ b/src/test/java/com/actiontech/dble/cluster/xmltoKv/XmlServerLoaderTest.java
@@ -1,4 +1,4 @@
-package com.actiontech.dble.cluster.xmlTokv;
+package com.actiontech.dble.cluster.xmltoKv;
 
 import com.actiontech.dble.cluster.ClusterPathUtil;
 import com.actiontech.dble.config.loader.zkprocess.entity.Server;


### PR DESCRIPTION
  unifiy package name of com.actiontech.dble.cluster.xmltoKv.

Reason:  
  fix #1680  
Type:  
  BUG
Influences：  
  fix package name inconsistency between com.actiontech.dble.cluster.xmltoKv and com.actiontech.dble.cluster.xmlTokv