### PR TITLE
#1688 - upgrade log4j from 2.7 to 2.8.2 due to safe problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,17 +139,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.7</version>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
-            <version>2.7</version>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>com.univocity</groupId>


### PR DESCRIPTION
Reason:  
  Improve #1688.  
Type:  
  Improve  
Influences：  
  log4j-slf4j-impl, log4j-core and log4j-1.2-api.
