### PR TITLE
#1672 add default JVM OOM config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,9 @@
                                     <extraArgument>-Xloggc:./logs/gc_%t_%p.log</extraArgument>
                                     <extraArgument>-XX:+PrintGCTimeStamps</extraArgument>
                                     <extraArgument>-XX:+PrintGCDetails</extraArgument>
+                                    <extraArgument>-XX:+HeapDumpOnOutOfMemoryError</extraArgument>
+                                    <extraArgument>-XX:HeapDumpPath=./logs/</extraArgument>
+                                    <extraArgument>-XX:OnOutOfMemoryError=kill -9 %p</extraArgument>
                                 </extraArguments>
                             </jvmSettings>
                             <generatorConfigurations>


### PR DESCRIPTION
Reason:  
  Improve #1672 
Type:  
  Improve  
Influences：  
   Catch Throwable exception would not invalidate HeapDumpOnOutOfMemoryError & OnOutOfMemoryError
   In OpenJDK the HeapDumpOnOutOfMemoryError & OnOutOfMemoryError follow the order that OnOutOfMemoryError would be called after HeapDumpOnOutOfMemoryError finished. But no detailed description with OracleJDK
