### PR TITLE
#1706 NestLoop may cause java.util.ConcurrentModificationException

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/JoinNodeHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/JoinNodeHandlerBuilder.java
@@ -111,7 +111,7 @@ class JoinNodeHandlerBuilder extends BaseHandlerBuilder {
                     buildNestFilters(tnBig, keyToPass, valueSet, tempHandler.getMaxPartSize());
                     DMLResponseHandler bigLh = buildJoinChild(tnBig, !isLeftSmall);
                     synchronized (tempHandler) {
-                        bigLh.setNextHandler(tempHandler.getNextHandler());
+                        bigLh.setNextHandlerOnly(tempHandler.getNextHandler());
                     }
                     tempHandler.setCreatedHandler(bigLh);
                     HandlerBuilder.startHandler(bigLh);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/BaseDMLHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/BaseDMLHandler.java
@@ -66,7 +66,7 @@ public abstract class BaseDMLHandler implements DMLResponseHandler {
     }
 
     @Override
-    public List<DMLResponseHandler> getMerges() {
+    public final List<DMLResponseHandler> getMerges() {
         return this.merges;
     }
 

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/BaseDMLHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/BaseDMLHandler.java
@@ -56,12 +56,17 @@ public abstract class BaseDMLHandler implements DMLResponseHandler {
     }
 
     @Override
+    public final void setNextHandlerOnly(DMLResponseHandler next) {
+        this.nextHandler = (BaseDMLHandler) next;
+    }
+
+    @Override
     public void setLeft(boolean left) {
         this.isLeft = left;
     }
 
     @Override
-    public final List<DMLResponseHandler> getMerges() {
+    public List<DMLResponseHandler> getMerges() {
         return this.merges;
     }
 

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/DMLResponseHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/DMLResponseHandler.java
@@ -20,6 +20,8 @@ public interface DMLResponseHandler extends ResponseHandler {
 
     void setNextHandler(DMLResponseHandler next);
 
+    void setNextHandlerOnly(DMLResponseHandler next);
+
     List<DMLResponseHandler> getMerges();
 
     boolean isAllPushDown();


### PR DESCRIPTION
Reason:  
  BUG #1706 
Type:  
  BUG  
Influences：  
   NestLoop may cause java.util.ConcurrentModificationException
