### PR TITLE
#1454 - dble reports error when columns don't contains sharding column in load data for sharding table.

### DIFF
--- a/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
@@ -12,8 +12,6 @@ import com.actiontech.dble.config.ErrorCode;
 import com.actiontech.dble.config.model.SchemaConfig;
 import com.actiontech.dble.config.model.SystemConfig;
 import com.actiontech.dble.config.model.TableConfig;
-import com.actiontech.dble.singleton.CacheService;
-import com.actiontech.dble.singleton.ProxyMeta;
 import com.actiontech.dble.meta.protocol.StructureMeta;
 import com.actiontech.dble.net.handler.LoadDataInfileHandler;
 import com.actiontech.dble.net.mysql.BinaryPacket;
@@ -27,6 +25,8 @@ import com.actiontech.dble.route.util.RouterUtil;
 import com.actiontech.dble.server.ServerConnection;
 import com.actiontech.dble.server.parser.ServerParse;
 import com.actiontech.dble.server.util.SchemaUtil;
+import com.actiontech.dble.singleton.CacheService;
+import com.actiontech.dble.singleton.ProxyMeta;
 import com.actiontech.dble.singleton.SequenceManager;
 import com.actiontech.dble.sqlengine.mpp.LoadData;
 import com.actiontech.dble.util.ObjectUtil;
@@ -275,6 +275,12 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
                         return false;
                     }
                 }
+            }
+
+            if (pColumn != null && partitionColumnIndex == -1) {
+                serverConnection.writeErrMessage(ErrorCode.ER_KEY_COLUMN_DOES_NOT_EXITS, "can't find partition column.");
+                clear();
+                return false;
             }
         }
         return true;


### PR DESCRIPTION
Reason:  
  BUG #1454.  
Type:  
  BUG/Improve  
Influences：  
   dble reports error when columns don't contains sharding column in load data for sharding column.
