### PR TITLE
#1725 - reuse other datanode conn of global table in singleNodeHandler

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
@@ -86,8 +86,6 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
                     RouteResultsetNode tmpNode = new RouteResultsetNode(dataNode, rrs.getSqlType(), rrs.getStatement());
                     conn = session.getTarget(tmpNode);
                     if (conn != null) {
-                        session.getTargetMap().remove(tmpNode);
-                        session.bindConnection(node, conn);
                         break;
                     }
                 }


### PR DESCRIPTION
Reason:  
  BUG #1725 .
Type:  
  BUG 
Influences：  
  reuse other datanode conn of global table in singleNodeHandler
