### PR TITLE
if value of binlog pause status in zk is empty, dble report ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/actiontech/dble/server/OfflineStatusListener.java
+++ b/src/main/java/com/actiontech/dble/server/OfflineStatusListener.java
@@ -91,7 +91,7 @@ public class OfflineStatusListener implements PathChildrenCacheListener {
         CuratorFramework zkConn = ZKUtils.getConnection();
         try {
             byte[] binlogStatusData = zkConn.getData().forPath(binlogStatusPath);
-            if (binlogStatusData == null) {
+            if (binlogStatusData == null || binlogStatusData.length == 0) {
                 return;
             }
             String data = new String(binlogStatusData, StandardCharsets.UTF_8);


### PR DESCRIPTION
Reason:  
  BUG inner453. 
Type:  
  BUG 
Influences：  
  if value of binlog pause status in zk is empty, dble report ArrayIndexOutOfBoundsException
