### PR TITLE
may NPException

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/savepoint/SavePointHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/transaction/savepoint/SavePointHandler.java
@@ -72,12 +72,12 @@ public class SavePointHandler extends MultiNodeHandler {
         }
 
         unResponseRrns.addAll(session.getTargetKeys());
+        this.performSp = newSp;
         for (RouteResultsetNode rrn : session.getTargetKeys()) {
             final BackendConnection conn = session.getTarget(rrn);
             conn.setResponseHandler(this);
             ((MySQLConnection) conn).execCmd("savepoint " + spName);
         }
-        this.performSp = newSp;
     }
 
     private void rollbackTo(String spName) {
@@ -102,6 +102,7 @@ public class SavePointHandler extends MultiNodeHandler {
 
         Set lastNodes = sp.getPrev().getRouteNodes();
         unResponseRrns.addAll(session.getTargetKeys());
+        this.performSp = sp;
         for (RouteResultsetNode rrn : session.getTargetKeys()) {
             final BackendConnection conn = session.getTarget(rrn);
             conn.setResponseHandler(this);
@@ -113,7 +114,6 @@ public class SavePointHandler extends MultiNodeHandler {
                 ((MySQLConnection) conn).execCmd("rollback to " + spName);
             }
         }
-        this.performSp = sp;
     }
 
     private void release(String spName) {


### PR DESCRIPTION
Reason:  
  BUG from autotest
Type:  
  BUG 
Influences：  
   ` 
WARN [backendBusinessExecutor1] (com.actiontech.dble.backend.mysql.nio.handler.transaction.savepoint.SavePointHandler.connectionError(SavePointHandler.java:207)) - connection Error in savePointHandler, err:
java.lang.NullPointerException: null

        at com.actiontech.dble.backend.mysql.nio.handler.transaction.savepoint.SavePointHandler.addSavePoint(SavePointHandler.java:148) ~[dble-9.9.9.9.jar:?]
        at com.actiontech.dble.backend.mysql.nio.handler.transaction.savepoint.SavePointHandler.cleanAndFeedback(SavePointHandler.java:228) ~[dble-9.9.9.9.jar:?]
        at com.actiontech.dble.backend.mysql.nio.handler.transaction.savepoint.SavePointHandler.okResponse(SavePointHandler.java:170) [dble-9.9.9.9.jar:?]
        at com.actiontech.dble.backend.mysql.nio.MySQLConnectionHandler.handleOkPacket(MySQLConnectionHandler.java:160) ~[dble-9.9.9.9.jar:?]
        at com.actiontech.dble.backend.mysql.nio.MySQLConnectionHandler.handleData(MySQLConnectionHandler.java:91) [dble-9.9.9.9.jar:?]
        at com.actiontech.dble.net.handler.BackendAsyncHandler.handleInnerData(BackendAsyncHandler.java:100) ~[dble-9.9.9.9.jar:?]
        at com.actiontech.dble.net.handler.BackendAsyncHandler.access$000(BackendAsyncHandler.java:19) ~[dble-9.9.9.9.jar:?]
        at com.actiontech.dble.net.handler.BackendAsyncHandler$1.run(BackendAsyncHandler.java:51) [dble-9.9.9.9.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_121]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_121]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_121]
` 