### PR TITLE
correct column name when statement of show tables contains like clause

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/ShowTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/ShowTablesHandler.java
@@ -36,6 +36,7 @@ public class ShowTablesHandler extends SingleNodeHandler {
     private Item whereItem;
     private List<Field> sourceFields;
     private ShowTablesStmtInfo info;
+
     public ShowTablesHandler(RouteResultset rrs, NonBlockingSession session, ShowTablesStmtInfo info) {
         super(rrs, session);
         buffer = session.getSource().allocate();
@@ -59,9 +60,13 @@ public class ShowTablesHandler extends SingleNodeHandler {
             if (writeToClient.get()) {
                 return;
             }
+            String schemaColumn = showTableSchema;
+            if (info.getLike() != null) {
+                schemaColumn = schemaColumn + " (" + info.getLike() + ")";
+            }
             if (info.isFull()) {
                 List<FieldPacket> fieldPackets = new ArrayList<>(2);
-                bufInf = ShowTables.writeFullTablesHeader(buffer, source, showTableSchema, fieldPackets);
+                bufInf = ShowTables.writeFullTablesHeader(buffer, source, schemaColumn, fieldPackets);
                 packetId = bufInf.getPacketId();
                 buffer = bufInf.getBuffer();
                 if (info.getWhere() != null) {
@@ -78,7 +83,7 @@ public class ShowTablesHandler extends SingleNodeHandler {
                     buffer = bufInf.getBuffer();
                 }
             } else {
-                bufInf = ShowTables.writeTablesHeaderAndRows(buffer, source, shardingTablesMap, showTableSchema);
+                bufInf = ShowTables.writeTablesHeaderAndRows(buffer, source, shardingTablesMap, schemaColumn);
                 packetId = bufInf.getPacketId();
                 buffer = bufInf.getBuffer();
             }

--- a/src/main/java/com/actiontech/dble/server/response/ShowTables.java
+++ b/src/main/java/com/actiontech/dble/server/response/ShowTables.java
@@ -116,9 +116,13 @@ public final class ShowTables {
         ByteBuffer buffer = c.allocate();
         Map<String, String> tableMap = getTableSet(cSchema, info);
         PackageBufINf bufInf;
+        String schemaColumn = cSchema;
+        if (info.getLike() != null) {
+            schemaColumn = schemaColumn + " (" + info.getLike() + ")";
+        }
         if (info.isFull()) {
             List<FieldPacket> fieldPackets = new ArrayList<>(2);
-            bufInf = writeFullTablesHeader(buffer, c, cSchema, fieldPackets);
+            bufInf = writeFullTablesHeader(buffer, c, schemaColumn, fieldPackets);
             if (info.getWhere() != null) {
                 MySQLItemVisitor mev = new MySQLItemVisitor(c.getSchema(), c.getCharset().getResultsIndex(), ProxyMeta.getInstance().getTmManager(), c.getUsrVariables());
                 info.getWhereExpr().accept(mev);
@@ -129,7 +133,7 @@ public final class ShowTables {
                 bufInf = writeFullTablesRow(bufInf.getBuffer(), c, tableMap, bufInf.getPacketId(), null, null);
             }
         } else {
-            bufInf = writeTablesHeaderAndRows(buffer, c, tableMap, cSchema);
+            bufInf = writeTablesHeaderAndRows(buffer, c, tableMap, schemaColumn);
         }
 
         writeRowEof(bufInf.getBuffer(), c, bufInf.getPacketId());


### PR DESCRIPTION
Reason:  
  BUG #1678 .
Type:  
  BUG 
Influences：  
  show tables from schema like 's%'
