### PR TITLE
occur 'No locks available' error when double open rocksdb in reload

### DIFF
--- a/src/main/java/com/actiontech/dble/cache/impl/EnchachePoolFactory.java
+++ b/src/main/java/com/actiontech/dble/cache/impl/EnchachePoolFactory.java
@@ -11,7 +11,7 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.config.CacheConfiguration;
 
-public class EnchachePooFactory extends CachePoolFactory {
+public class EnchachePoolFactory extends CachePoolFactory {
 
     @Override
     public CachePool createCachePool(String poolName, int cacheSize,

--- a/src/main/java/com/actiontech/dble/cache/impl/RocksDBCachePoolFactory.java
+++ b/src/main/java/com/actiontech/dble/cache/impl/RocksDBCachePoolFactory.java
@@ -8,11 +8,8 @@ package com.actiontech.dble.cache.impl;
 import com.actiontech.dble.cache.CachePool;
 import com.actiontech.dble.cache.CachePoolFactory;
 import org.rocksdb.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RocksDBCachePoolFactory extends CachePoolFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RocksDBCachePoolFactory.class);
 
     @Override
     public CachePool createCachePool(String poolName, int cacheSize, int expireSeconds) {
@@ -35,30 +32,14 @@ public class RocksDBCachePoolFactory extends CachePoolFactory {
             } else {
                 db = RocksDB.open(options, path);
             }
-            final RocksDB finalDB = db;
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                public void run() {
-                    FlushOptions fo = new FlushOptions();
-                    fo.setWaitForFlush(true);
-                    try {
-                        finalDB.flush(fo);
-                    } catch (RocksDBException e) {
-                        LOGGER.warn("RocksDB flush error", e);
-                    } finally {
-                        finalDB.close();
-                        fo.close();
-                        options.close();
-                    }
-                }
-            });
-            return new RocksDBPool(db, poolName, cacheSize);
+            return new RocksDBPool(db, options, poolName, cacheSize);
         } catch (RocksDBException e) {
             throw new InitStoreException(e);
         }
     }
 
     public static class InitStoreException extends RuntimeException {
-        public InitStoreException(Throwable cause) {
+        InitStoreException(Throwable cause) {
             super(cause);
         }
     }

--- a/src/main/java/com/actiontech/dble/cache/impl/RocksDBPool.java
+++ b/src/main/java/com/actiontech/dble/cache/impl/RocksDBPool.java
@@ -8,6 +8,7 @@ package com.actiontech.dble.cache.impl;
 import com.actiontech.dble.cache.CachePool;
 import com.actiontech.dble.cache.CacheStatic;
 import org.nustaq.serialization.FSTConfiguration;
+import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,13 +16,15 @@ import org.slf4j.LoggerFactory;
 public class RocksDBPool implements CachePool {
     private static final Logger LOGGER = LoggerFactory.getLogger(RocksDBPool.class);
     private final RocksDB cache;
+    private final Options dbOptions;
     private final CacheStatic cacheStatistics = new CacheStatic();
     private final String name;
     private final long maxSize;
     private FSTConfiguration fst = FSTConfiguration.createDefaultConfiguration();
 
-    public RocksDBPool(RocksDB cache, String name, long maxSize) {
+    RocksDBPool(RocksDB cache, Options options, String name, long maxSize) {
         this.cache = cache;
+        this.dbOptions = options;
         this.name = name;
         this.maxSize = maxSize;
     }
@@ -69,7 +72,8 @@ public class RocksDBPool implements CachePool {
         LOGGER.info("clear cache " + name);
         //cache.delete(key);
         cacheStatistics.reset();
-        //cacheStati.setMemorySize(cache.g);
+        cache.close();
+        dbOptions.close();
     }
 
     @Override

--- a/src/main/java/com/actiontech/dble/singleton/CacheService.java
+++ b/src/main/java/com/actiontech/dble/singleton/CacheService.java
@@ -9,7 +9,7 @@ import com.actiontech.dble.cache.CachePool;
 import com.actiontech.dble.cache.CachePoolFactory;
 import com.actiontech.dble.cache.DefaultLayedCachePool;
 import com.actiontech.dble.cache.LayerCachePool;
-import com.actiontech.dble.cache.impl.EnchachePooFactory;
+import com.actiontech.dble.cache.impl.EnchachePoolFactory;
 import com.actiontech.dble.cache.impl.LevelDBCachePooFactory;
 import com.actiontech.dble.cache.impl.MapDBCachePooFactory;
 import com.actiontech.dble.cache.impl.RocksDBCachePoolFactory;
@@ -38,7 +38,11 @@ public final class CacheService {
     private final ConcurrentMap<String, CachePool> allPools = new ConcurrentHashMap<>();
 
     private CacheService() {
-
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                clearCache();
+            }
+        });
     }
 
     public static CacheService getInstance() {
@@ -137,7 +141,7 @@ public final class CacheService {
         String lowerClass = factryClassName.toLowerCase();
         switch (lowerClass) {
             case "ehcache":
-                poolFactories.put(factoryType, new EnchachePooFactory());
+                poolFactories.put(factoryType, new EnchachePoolFactory());
                 break;
             case "leveldb":
                 poolFactories.put(factoryType, new LevelDBCachePooFactory());
@@ -199,16 +203,13 @@ public final class CacheService {
             pool.clearCache();
         }
         allPools.clear();
-        try {
-            init(isLowerCaseTableNames);
-        } catch (Exception e) {
-            throw e;
-        }
+        init(isLowerCaseTableNames);
     }
 
     public static CachePool getSqlRouteCache() {
         return INSTANCE.getCachePool(SQL_ROUTE_CACHE);
     }
+
     public static CachePool getCachePoolByName(String poolName) {
         return INSTANCE.getCachePool(poolName);
     }

--- a/src/test/java/com/actiontech/dble/cache/DefaultLayedCachePoolTest.java
+++ b/src/test/java/com/actiontech/dble/cache/DefaultLayedCachePoolTest.java
@@ -5,7 +5,7 @@
 */
 package com.actiontech.dble.cache;
 
-import com.actiontech.dble.cache.impl.EnchachePooFactory;
+import com.actiontech.dble.cache.impl.EnchachePoolFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,7 +15,7 @@ public class DefaultLayedCachePoolTest {
 
     static {
 
-        layedCachePool = new DefaultLayedCachePool("defaultLayedPool", new EnchachePooFactory(), 1000, 1);
+        layedCachePool = new DefaultLayedCachePool("defaultLayedPool", new EnchachePoolFactory(), 1000, 1);
 
     }
 


### PR DESCRIPTION
Reason:  
  BUG #inner 325
Type:  
  BUG
Influences：  
  occur 'No locks available' error when double open rocksdb in reload
