### PR TITLE
ddl of rename index in mysql 5.6 isn't online ddl

### DIFF
--- a/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidAlterTableParser.java
+++ b/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidAlterTableParser.java
@@ -51,7 +51,6 @@ public class DruidAlterTableParser extends DefaultDruidParser {
                 support = true;
             } else if (alterItem instanceof SQLAlterTableAddIndex ||
                     alterItem instanceof SQLAlterTableDropIndex ||
-                    alterItem instanceof SQLAlterTableRenameIndex ||
                     alterItem instanceof MySqlAlterTableAlterColumn) {
                 support = true;
                 rrs.setOnline(true);


### PR DESCRIPTION
Reason:  
  BUG #inner370.
Type:  
  BUG
Influences：  
  ddl of rename index in mysql 5.6 isn't online ddl
