### PR TITLE
reset initial flag when connection pool was stopped

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
@@ -352,6 +352,7 @@ public abstract class PhysicalDbInstance {
         LOGGER.info("stop connection pool of physical db instance[{}], due to {}", name, reason);
         heartbeat.stop(reason);
         connectionPool.stop(reason, closeFront);
+        isInitial.set(false);
     }
 
     public void closeAllConnection(String reason) {
@@ -439,9 +440,9 @@ public abstract class PhysicalDbInstance {
     @Override
     public String toString() {
         return "dbInstance[name=" + name +
-                ",disabled=" +
-                disabled.toString() + ",maxCon=" +
-                config.getMaxCon() + "]";
+                ",disabled=" + disabled.toString() +
+                ",maxCon=" + config.getMaxCon() +
+                ",minCon=" + config.getMinCon() + "]";
     }
 
 }


### PR DESCRIPTION
Reason:  
  BUG #inner 448.
Type:  
  BUG 
Influences：  
  reset initial flag when connection pool was stopped
