### PR TITLE
handle the rwSplitMode of this dbGroup is 0 scenario，and remove duplicate dbInstanceName

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
@@ -119,6 +119,10 @@ public class PhysicalDbGroup {
         return !(writeDbInstance == ds);
     }
 
+    public int getRwSplitMode() {
+        return rwSplitMode;
+    }
+
     public PhysicalDbInstance getWriteDbInstance() {
         return writeDbInstance;
     }
@@ -134,7 +138,7 @@ public class PhysicalDbGroup {
         }
     }
 
-    public void init(String[] sourceNames, String reason, boolean isFresh) {
+    public void init(List<String> sourceNames, String reason, boolean isFresh) {
         if (rwSplitMode == 0) {
             writeDbInstance.init(reason, isFresh);
             return;
@@ -157,7 +161,7 @@ public class PhysicalDbGroup {
         }
     }
 
-    public void stop(String[] sourceNames, String reason, boolean closeFront) {
+    public void stop(List<String> sourceNames, String reason, boolean closeFront) {
         for (String sourceName : sourceNames) {
             if (allSourceMap.containsKey(sourceName)) {
                 allSourceMap.get(sourceName).stop(reason, closeFront);
@@ -170,7 +174,7 @@ public class PhysicalDbGroup {
                 PooledConnection con = iterator.next();
                 if (con instanceof BackendConnection) {
                     BackendConnection backendCon = (BackendConnection) con;
-                    if (backendCon.getPoolDestroyedTime() != 0 && Arrays.asList(sourceNames).contains(backendCon.getInstance().getConfig().getInstanceName())) {
+                    if (backendCon.getPoolDestroyedTime() != 0 && sourceNames.contains(backendCon.getInstance().getConfig().getInstanceName())) {
                         backendCon.closeWithFront("old active backend conn will be forced closed by closing front conn");
                         iterator.remove();
                     }

--- a/src/main/java/com/actiontech/dble/services/manager/response/FreshBackendConn.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/FreshBackendConn.java
@@ -45,7 +45,7 @@ public final class FreshBackendConn {
                 if (dh.getRwSplitMode() == PhysicalDbGroup.RW_SPLIT_OFF && (!sourceNames.contains(dh.getWriteDbInstance().getName()))) {
                     warnMsg = "the rwSplitMode of this dbGroup is 0, so connection pool for slave dbInstance don't refresh";
                 } else {
-                    if (sourceNames.size() > 1 && sourceNames.contains(dh.getWriteDbInstance().getName())) {
+                    if (dh.getRwSplitMode() == PhysicalDbGroup.RW_SPLIT_OFF && sourceNames.size() > 1 && sourceNames.contains(dh.getWriteDbInstance().getName())) {
                         warnMsg = "the rwSplitMode of this dbGroup is 0, so connection pool for slave dbInstance don't refresh";
                     }
                     dh.stop(sourceNames, "fresh backend conn", isForced);

--- a/src/main/java/com/actiontech/dble/services/manager/response/FreshBackendConn.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/FreshBackendConn.java
@@ -7,8 +7,10 @@ import com.actiontech.dble.net.mysql.OkPacket;
 import com.actiontech.dble.services.manager.ManagerService;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 public final class FreshBackendConn {
 
@@ -34,11 +36,21 @@ public final class FreshBackendConn {
                 return;
             }
 
+            String warnMsg = null;
             // single
             try {
                 String[] nameList = instanceNames == null ? Arrays.copyOf(dh.getAllDbInstanceMap().keySet().toArray(), dh.getAllDbInstanceMap().keySet().toArray().length, String[].class) : instanceNames.split(",");
-                dh.stop(nameList, "fresh backend conn", isForced);
-                dh.init(nameList, "fresh backend conn", true);
+                List<String> sourceNames = Arrays.asList(nameList).stream().distinct().collect(Collectors.toList());
+
+                if (dh.getRwSplitMode() == PhysicalDbGroup.RW_SPLIT_OFF && (!sourceNames.contains(dh.getWriteDbInstance().getName()))) {
+                    warnMsg = "the rwSplitMode of this dbGroup is 0, so connection pool for slave dbInstance don't refresh";
+                } else {
+                    if (sourceNames.size() > 1 && sourceNames.contains(dh.getWriteDbInstance().getName())) {
+                        warnMsg = "the rwSplitMode of this dbGroup is 0, so connection pool for slave dbInstance don't refresh";
+                    }
+                    dh.stop(sourceNames, "fresh backend conn", isForced);
+                    dh.init(sourceNames, "fresh backend conn", true);
+                }
             } catch (Exception e) {
                 service.writeErrMessage(ErrorCode.ER_YES, "disable dbGroup with error, use show @@backend to check latest status. Error:" + e.getMessage());
                 e.printStackTrace();
@@ -48,6 +60,9 @@ public final class FreshBackendConn {
             OkPacket packet = new OkPacket();
             packet.setPacketId(1);
             packet.setAffectedRows(0);
+            if (warnMsg != null) {
+                packet.setMessage(warnMsg.getBytes());
+            }
             packet.setServerStatus(2);
             packet.write(service.getConnection());
         } finally {


### PR DESCRIPTION
handle the rwSplitMode of this dbGroup is 0 scenario，and remove duplicate dbInstanceName

Reason:  
  BUG  
Type:  
  Improve  
Influences：  
   handle the rwSplitMode of this dbGroup is 0 scenario，and remove duplicate dbInstanceName
