### PR TITLE
use connection out of connection pool to get table meta when dryrun

### DIFF
--- a/src/main/java/com/actiontech/dble/manager/response/DryRun.java
+++ b/src/main/java/com/actiontech/dble/manager/response/DryRun.java
@@ -52,8 +52,7 @@ public final class DryRun {
         byte packetId = 0;
         HEADER.setPacketId(++packetId);
 
-        FIELDS[i] = PacketUtil.getField("TYPE",
-                Fields.FIELD_TYPE_VAR_STRING);
+        FIELDS[i] = PacketUtil.getField("TYPE", Fields.FIELD_TYPE_VAR_STRING);
         FIELDS[i++].setPacketId(++packetId);
 
         FIELDS[i] = PacketUtil.getField("LEVEL", Fields.FIELD_TYPE_VAR_STRING);
@@ -97,13 +96,11 @@ public final class DryRun {
             list.add(new ErrorInfo("Backend", "ERROR", e.getMessage()));
         }
 
-
         list.addAll(loader.getErrorInfos());
 
         ServerConfig serverConfig = new ServerConfig(loader);
-        SystemVariables newSystemVariables = null;
         VarsExtractorHandler handler = new VarsExtractorHandler(loader.getDbGroups());
-        newSystemVariables = handler.execute();
+        SystemVariables newSystemVariables = handler.execute();
         if (newSystemVariables == null) {
             if (loader.isFullyConfigured()) {
                 list.add(new ErrorInfo("Backend", "ERROR", "Get Vars from backend failed,Maybe all backend MySQL can't connected"));
@@ -123,10 +120,6 @@ public final class DryRun {
             } catch (Exception e) {
                 list.add(new ErrorInfo("Xml", "ERROR", e.getMessage()));
             }
-        }
-
-        if (handler.getUsedDbInstance() != null) {
-            handler.getUsedDbInstance().closeAllConnection("dry run end");
         }
 
         userCheck(list, serverConfig);
@@ -158,7 +151,7 @@ public final class DryRun {
 
         for (SchemaConfig schema : serverConfig.getSchemas().values()) {
             for (BaseTableConfig table : schema.getTables().values()) {
-                StringBuilder sb = new StringBuilder("");
+                StringBuilder sb = new StringBuilder(100);
                 for (String exDn : table.getShardingNodes()) {
                     if (tableMap.get(exDn) != null && !tableMap.get(exDn).contains(table.getName())) {
                         sb.append(exDn).append(",");

--- a/src/main/java/com/actiontech/dble/sqlengine/SpecialSqlJob.java
+++ b/src/main/java/com/actiontech/dble/sqlengine/SpecialSqlJob.java
@@ -45,25 +45,18 @@ public class SpecialSqlJob extends SQLJob {
         this.finished = new AtomicBoolean(false);
     }
 
-
     public void run() {
-        try {
-            //create new connection and exec the sql
-            DbleServer.getInstance().getComplexQueryExecutor().execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        ds.getConnection(schema, sqlJob, null, false);
-                    } catch (Exception e) {
-                        sqlJob.connectionError(e, null);
-                    }
+        //create new connection and exec the sql
+        DbleServer.getInstance().getComplexQueryExecutor().execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    ds.createConnectionSkipPool(schema, sqlJob);
+                } catch (Exception e) {
+                    sqlJob.connectionError(e, null);
                 }
-            });
-
-        } catch (Exception e) {
-            LOGGER.warn("can't get connection", e);
-            doFinished(true);
-        }
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Reason:  
  Improve #1879 .  
Type:  
  Improve  
Influences：  
  use connection out of connection pool to get table meta when dryrun
