### PR TITLE
fix for slave instance keeps a heartbeat connection when rwSplitMode== RW_SPLIT_OFF

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
@@ -351,7 +351,7 @@ public abstract class PhysicalDbInstance {
     }
 
     public void start(String reason) {
-        if (dbGroupConfig.getRwSplitMode() != RW_SPLIT_OFF) {
+        if (dbGroupConfig.getRwSplitMode() != RW_SPLIT_OFF || dbGroup.getWriteDbInstance() == this) {
             LOGGER.info("start connection pool of physical db instance[{}], due to {}", name, reason);
             this.connectionPool.startEvictor();
         }
@@ -360,7 +360,7 @@ public abstract class PhysicalDbInstance {
 
     public void stop(String reason, boolean closeFront) {
         heartbeat.stop(reason);
-        if (dbGroupConfig.getRwSplitMode() != RW_SPLIT_OFF) {
+        if (dbGroupConfig.getRwSplitMode() != RW_SPLIT_OFF || dbGroup.getWriteDbInstance() == this) {
             LOGGER.info("stop connection pool of physical db instance[{}], due to {}", name, reason);
             connectionPool.stop(reason, closeFront);
         }


### PR DESCRIPTION
Reason:  
  BUG #inner 465. 
Type:  
  BUG
Influences：  
   fix for slave instance keeps a heartbeat connection when rwSplitMode== RW_SPLIT_OFF
