### PR TITLE
fix: Remove -DbufferPoolPageNumber from bootstrap_template.cnf

### DIFF
--- a/src/main/resources/bootstrap_template.cnf
+++ b/src/main/resources/bootstrap_template.cnf
@@ -91,7 +91,7 @@
 
 #  off Heap unit:bytes
 -DbufferPoolChunkSize=32767
--DbufferPoolPageNumber=256
+#-DbufferPoolPageNumber=256
 -DbufferPoolPageSize=2097152
 #-DmappedFileSize=2097152
 


### PR DESCRIPTION
Reason:  
  Improve
Type:  
  Improve  
Influences：  
  fix: Remove -DbufferPoolPageNumber from bootstrap_template.cnf
