### PR TITLE
add primary key for manager table (#2306)

### DIFF
--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/BackendVariables.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/BackendVariables.java
@@ -30,10 +30,10 @@ public class BackendVariables extends ManagerBaseTable {
 
     @Override
     protected void initColumnAndType() {
-        columns.put(COLUMN_BACKED_ID, new ColumnMeta(COLUMN_BACKED_ID, "int(11)", false));
+        columns.put(COLUMN_BACKED_ID, new ColumnMeta(COLUMN_BACKED_ID, "int(11)", false, true));
         columnsType.put(COLUMN_BACKED_ID, Fields.FIELD_TYPE_LONG);
 
-        columns.put(COLUMN_VAR_NAME, new ColumnMeta(COLUMN_VAR_NAME, "varchar(12)", false));
+        columns.put(COLUMN_VAR_NAME, new ColumnMeta(COLUMN_VAR_NAME, "varchar(12)", false, true));
         columnsType.put(COLUMN_VAR_NAME, Fields.FIELD_TYPE_VAR_STRING);
 
         columns.put(COLUMN_VAR_VALUE, new ColumnMeta(COLUMN_VAR_VALUE, "varchar(12)", false));

--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/ProcessList.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/ProcessList.java
@@ -36,10 +36,10 @@ public class ProcessList extends ManagerBaseTable {
 
     @Override
     protected void initColumnAndType() {
-        columns.put(COLUMN_FRONT_ID, new ColumnMeta(COLUMN_FRONT_ID, "int(11)", false));
+        columns.put(COLUMN_FRONT_ID, new ColumnMeta(COLUMN_FRONT_ID, "int(11)", false, true));
         columnsType.put(COLUMN_FRONT_ID, Fields.FIELD_TYPE_LONG);
 
-        columns.put(COLUMN_SHARDING_NODE, new ColumnMeta(COLUMN_SHARDING_NODE, "varchar(12)", false));
+        columns.put(COLUMN_SHARDING_NODE, new ColumnMeta(COLUMN_SHARDING_NODE, "varchar(12)", false, true));
         columnsType.put(COLUMN_SHARDING_NODE, Fields.FIELD_TYPE_VAR_STRING);
 
         columns.put(COLUMN_DB_INSTANCE, new ColumnMeta(COLUMN_DB_INSTANCE, "varchar(12)", false));

--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/SessionVariables.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/SessionVariables.java
@@ -30,10 +30,10 @@ public class SessionVariables extends ManagerBaseTable {
 
     @Override
     protected void initColumnAndType() {
-        columns.put(COLUMN_FRONT_ID, new ColumnMeta(COLUMN_FRONT_ID, "int(11)", false));
+        columns.put(COLUMN_FRONT_ID, new ColumnMeta(COLUMN_FRONT_ID, "int(11)", false, true));
         columnsType.put(COLUMN_FRONT_ID, Fields.FIELD_TYPE_LONG);
 
-        columns.put(COLUMN_VAR_NAME, new ColumnMeta(COLUMN_VAR_NAME, "varchar(12)", false));
+        columns.put(COLUMN_VAR_NAME, new ColumnMeta(COLUMN_VAR_NAME, "varchar(12)", false, true));
         columnsType.put(COLUMN_VAR_NAME, Fields.FIELD_TYPE_VAR_STRING);
 
         columns.put(COLUMN_VAR_VALUE, new ColumnMeta(COLUMN_VAR_VALUE, "varchar(12)", false));


### PR DESCRIPTION
* add primary key for manager table

* modify dryrun tips

(cherry picked from commit 189830a9245ae7dfb6b77e1821b125b92bb55350)

Reason:  
  Improve.  
Type:  
  Improve  
Influences：  
  add primary key for manager table (#2306)
