### PR TITLE
Merge with hint

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
@@ -527,4 +527,21 @@ public abstract class BaseHandlerBuilder {
         }
     }
 
+    public RouteResultsetNode[] filterRRSNode(RouteResultsetNode[] complexNodes, RouteResultsetNode[] hintNodes) {
+        RouteResultsetNode[] retNodes = new RouteResultsetNode[hintNodes.length];
+        int count = 0;
+        for (RouteResultsetNode hNode : hintNodes) {
+            for (RouteResultsetNode cNode : complexNodes) {
+                String hName = hNode.getName();
+                String cName = cNode.getName();
+                if (hName.equals(cName)) {
+                    retNodes[count] = cNode;
+                    count++;
+                    break;
+                }
+            }
+        }
+        return retNodes;
+    }
+
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/JoinNodeHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/JoinNodeHandlerBuilder.java
@@ -79,6 +79,12 @@ class JoinNodeHandlerBuilder extends BaseHandlerBuilder {
             } else {
                 rrs = mergeBuilder.constructByStatement(sql, mapTableToSimple, node.getAst(), schemaConfig);
             }
+
+            RouteResultsetNode[] newNodes = this.session.getHintNodes();
+            if (newNodes != null) {
+                rrs.setNodes(this.filterRRSNode(rrs.getNodes(), newNodes));
+            }
+
             buildMergeHandler(node, rrs.getNodes());
         } catch (Exception e) {
             throw new MySQLOutPutException(ErrorCode.ER_QUERYHANDLER, "", "join node mergebuild exception! Error:" + e.getMessage(), e);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/JoinNodeHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/JoinNodeHandlerBuilder.java
@@ -29,6 +29,8 @@ import com.actiontech.dble.server.NonBlockingSession;
 
 import java.util.*;
 
+import com.actiontech.dble.route.RouteResultsetNode;
+
 import static com.actiontech.dble.plan.optimizer.JoinStrategyProcessor.NEED_REPLACE;
 
 class JoinNodeHandlerBuilder extends BaseHandlerBuilder {

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/TableNodeHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/TableNodeHandlerBuilder.java
@@ -63,6 +63,12 @@ class TableNodeHandlerBuilder extends BaseHandlerBuilder {
             } else {
                 rrs = mergeBuilder.constructByStatement(sql, mapTableToSimple, node.getAst(), schemaConfig);
             }
+
+            RouteResultsetNode[] newNodes = this.session.getHintNodes();
+            if (newNodes != null) {
+                rrs.setNodes(this.filterRRSNode(rrs.getNodes(), newNodes));
+            }
+
             buildMergeHandler(node, rrs.getNodes());
         } catch (Exception e) {
             throw new MySQLOutPutException(ErrorCode.ER_QUERYHANDLER, "", "table node buildOwn exception! Error:" + e.getMessage(), e);

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -614,9 +614,9 @@ public class NonBlockingSession extends Session {
         }
     }
 
-    public void executeMultiSelectforBoguan(RouteResultset rrs) {
+    public void executeMultiSelectEx(RouteResultset rrs) {
         String realSQL = rrs.getNodes()[0].getStatement();
-        String routeSQL = rrs.getSrcStatement(
+        String routeSQL = rrs.getSrcStatement();
         if (routeSQL.equals(realSQL)) { // really simple sql
             executeOther(rrs);
         } else { //come with hint

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -495,7 +495,11 @@ public class NonBlockingSession extends Session {
             } else {
                 setRouteResultToTrace(nodes);
                 // hint query also need backend aggregator operation.
-                executeMultiSelectEx(rrs);
+                if (rrs.getSqlType() == ServerParse.SELECT) {
+                    executeMultiSelectEx(rrs);
+                } else {
+                    executeOther(rrs);
+                }
             }
         } finally {
             TraceManager.finishSpan(shardingService, traceObject);

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -637,7 +637,7 @@ public class NonBlockingSession extends Session {
                         shardingService.writeErrMessage(e.getSqlState(), e.getMessage(), e.getErrorCode());
                     }
                 } else {
-                    RouteResultsetNode[] hintNodes = rrs.getNodes();
+                    this.setHintNodes(rrs.getNodes());
                     RouteResultsetNode[] complexNodes = newrrs.getNodes();
                     RouteResultsetNode[] retNodes = new RouteResultsetNode[hintNodes.length];
                     int count = 0;


### PR DESCRIPTION
I. What Changed:
    when route with hint, there are two sql statement: one is hint sql, the other is real sql.
    first,  get the route from hint sql, and save it into current session instance.
    second, get the route from real sql, and check
        if real sql is complex query, then  run executeMultiSelect(), and  filter the real SQL's RRS nodes with hint RRS node before buildMergeHandler() is called
        if real sql is simple query, then run executeOther()
       
II. Why this change was make
When quering with hint,  the default logic of dble will run query on hint-routed nodes and simply concatenate the result from each node, which is not acceptable for my customer.  the requirement is that hint-routed complex query also need to be merged.   