### PR TITLE
'-javaagent' configuration item is supported in the bootstrap.cnf

### DIFF
--- a/src/main/java/com/actiontech/dble/config/loader/SystemConfigLoader.java
+++ b/src/main/java/com/actiontech/dble/config/loader/SystemConfigLoader.java
@@ -50,7 +50,7 @@ public final class SystemConfigLoader {
                 }
                 // only support these option
                 if (line.startsWith("-server") || line.startsWith("-X") || line.startsWith("-agentlib") ||
-                        line.startsWith("-Dcom.sun.management.jmxremote")) {
+                        line.startsWith("-javaagent") || line.startsWith("-Dcom.sun.management.jmxremote")) {
                     continue;
                 }
                 int ind = line.indexOf('=');


### PR DESCRIPTION
Reason:  
  BUG inner 789
Type:  
  BUG
Influences：  
  '-javaagent' configuration item is supported in the bootstrap.cnf
