### PR TITLE
fix: problems with set names and set charset

### DIFF
--- a/src/main/java/com/actiontech/dble/services/BusinessService.java
+++ b/src/main/java/com/actiontech/dble/services/BusinessService.java
@@ -90,7 +90,7 @@ public abstract class BusinessService extends FrontEndService {
                     }
                     break;
                 case CHARSET:
-                    this.setCharacterSet(variable.getValue());
+                    this.setNames(variable.getValue(), "@@session.collation_database");
                     break;
                 case NAMES:
                     String[] charsetAndCollate = variable.getValue().split(":");

--- a/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitHandler.java
+++ b/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitHandler.java
@@ -38,7 +38,7 @@ public class RWSplitHandler implements ResponseHandler, LoadDataResponseHandler,
         if (originPacket != null) {
             mysqlService.execute(rwSplitService, originPacket);
         } else {
-            mysqlService.execute(rwSplitService, rwSplitService.getExecuteSql());
+            mysqlService.execute(rwSplitService, rwSplitService.getExecuteSqlBytes());
         }
     }
 

--- a/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitService.java
+++ b/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitService.java
@@ -33,6 +33,7 @@ public class RWSplitService extends BusinessService {
     private volatile boolean inPrepare;
 
     private volatile String executeSql;
+    private volatile byte[] executeSqlBytes;
     // only for test
     private volatile String expectedDest;
 
@@ -179,6 +180,7 @@ public class RWSplitService extends BusinessService {
                 }
             }
             executeSql = sql;
+            executeSqlBytes = data;
             queryHandler.query(sql);
         } catch (UnsupportedEncodingException e) {
             writeErrMessage(ErrorCode.ER_UNKNOWN_COM_ERROR, e.getMessage());
@@ -232,6 +234,9 @@ public class RWSplitService extends BusinessService {
         this.executeSql = executeSql;
     }
 
+    public byte[] getExecuteSqlBytes() {
+        return executeSqlBytes;
+    }
 
     public boolean isLocked() {
         return isLocked;


### PR DESCRIPTION
Reason:  
  BUG inner 603/605/606
Type:  
  BUG
Influences：  
  fix: problems with set names and set charset
1.Ensure that the input sql character set of dble and mysql is consistent
2.This statement maps all strings sent between the server and the current client with the given mapping. SET CHARACTER SET sets three session system variables: character_set_client and character_set_results are set to the given character set, and character_set_connection to the value of character_set_database.
ref:https://dev.mysql.com/doc/refman/5.7/en/set-character-set.html
