### PR TITLE
inner-557: fixed: temporary table query should send to master

### DIFF
--- a/src/main/java/com/actiontech/dble/rwsplit/RWSplitNonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/rwsplit/RWSplitNonBlockingSession.java
@@ -56,7 +56,7 @@ public class RWSplitNonBlockingSession {
     }
 
     private Boolean canRunOnMaster(Boolean master) {
-        if (!rwSplitService.isAutocommit() || rwSplitService.isTxStart()) {
+        if (!rwSplitService.isAutocommit() || rwSplitService.isTxStart() || rwSplitService.isUsingTmpTable()) {
             return true;
         }
         return master;
@@ -139,7 +139,7 @@ public class RWSplitNonBlockingSession {
     public void unbindIfSafe() {
         if (rwSplitService.isAutocommit() && !rwSplitService.isTxStart() && !rwSplitService.isLocked() &&
                 !rwSplitService.isInLoadData() &&
-                !rwSplitService.isInPrepare() && this.conn != null) {
+                !rwSplitService.isInPrepare() && this.conn != null && !rwSplitService.isUsingTmpTable()) {
             this.conn.release();
             this.conn = null;
         }

--- a/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitQueryHandler.java
+++ b/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitQueryHandler.java
@@ -7,6 +7,7 @@ import com.actiontech.dble.server.ServerQueryHandler;
 import com.actiontech.dble.server.handler.SetHandler;
 import com.actiontech.dble.server.handler.UseHandler;
 import com.actiontech.dble.server.parser.RwSplitServerParse;
+import com.actiontech.dble.services.rwsplit.handle.TempTableHandler;
 import com.actiontech.dble.singleton.RouteService;
 import com.actiontech.dble.singleton.TraceManager;
 import com.google.common.collect.ImmutableMap;
@@ -87,6 +88,12 @@ public class RWSplitQueryHandler implements FrontendQueryHandler {
                         break;
                     case RwSplitServerParse.HELP:
                         session.execute(null, null);
+                        break;
+                    case RwSplitServerParse.CREATE_TEMPORARY_TABLE:
+                        TempTableHandler.handleCreate(sql, session.getService(), rs >>> 8);
+                        break;
+                    case RwSplitServerParse.DROP_TEMPORARY_TABLE:
+                        TempTableHandler.handleDrop(sql, session.getService(), rs >>> 8);
                         break;
                     default:
                         // 1. DDL

--- a/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitService.java
+++ b/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitService.java
@@ -20,6 +20,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,6 +33,8 @@ public class RWSplitService extends BusinessService {
     private volatile boolean isLocked;
     private volatile boolean inLoadData;
     private volatile boolean inPrepare;
+    private volatile boolean usingTmpTable = false;
+    private Set<String/* tableName */> tmpTableSet;
 
     private volatile String executeSql;
     // only for test
@@ -252,6 +256,22 @@ public class RWSplitService extends BusinessService {
     public boolean isInPrepare() {
         return inPrepare;
     }
+
+    public boolean isUsingTmpTable() {
+        return usingTmpTable;
+    }
+
+    public void setUsingTmpTable(boolean usingTmpTable) {
+        this.usingTmpTable = usingTmpTable;
+    }
+
+    public Set<String> getTmpTableSet() {
+        if (tmpTableSet == null) {
+            tmpTableSet = new HashSet<>();
+        }
+        return tmpTableSet;
+    }
+
 
     public void setInPrepare(boolean inPrepare) {
         this.inPrepare = inPrepare;

--- a/src/main/java/com/actiontech/dble/services/rwsplit/handle/TempTableHandler.java
+++ b/src/main/java/com/actiontech/dble/services/rwsplit/handle/TempTableHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2020 ActionTech.
+ * based on code by MyCATCopyrightHolder Copyright (c) 2013, OpenCloudDB/MyCAT.
+ * License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher.
+ */
+
+package com.actiontech.dble.services.rwsplit.handle;
+
+import com.actiontech.dble.rwsplit.RWSplitNonBlockingSession;
+import com.actiontech.dble.services.rwsplit.RWSplitService;
+
+import java.util.Set;
+
+/**
+ * @author dcy
+ * Create Date: 2020-12-15
+ */
+public final class TempTableHandler {
+    private TempTableHandler() {
+    }
+
+    public static void handleCreate(String stmt, RWSplitService service, int offset) {
+        final int rightTerminatorOffset = stmt.indexOf("(");
+        final String tableName = stmt.substring(offset, rightTerminatorOffset).trim();
+        final RWSplitNonBlockingSession session = service.getSession();
+
+        session.execute(true, (isSuccess, rwSplitService) -> {
+            final Set<String> tempTableSet = rwSplitService.getTmpTableSet();
+            tempTableSet.add(tableName);
+            rwSplitService.setUsingTmpTable(true);
+        });
+    }
+
+
+    public static void handleDrop(String stmt, RWSplitService service, int offset) {
+
+        final String tableName = stmt.substring(offset).trim();
+        final RWSplitNonBlockingSession session = service.getSession();
+
+        session.execute(true, (isSuccess, rwSplitService) -> {
+            final Set<String> tempTableSet = rwSplitService.getTmpTableSet();
+            tempTableSet.remove(tableName);
+            if (tempTableSet.isEmpty()) {
+                rwSplitService.setUsingTmpTable(false);
+            }
+
+        });
+    }
+}


### PR DESCRIPTION
Reason:  
  In RwSplit scenarios, the `create temporary table` query doesn't send to the master. But the 'select from temporary table' query send to slave. So cause `table not found ` error.
Type:  
  BUG  inner 557
Influences：  

- If I create a temporary table, all queries would send to master unless drop all temporary tables afterward. 
  