### PR TITLE
Inner 711&631: fixed:multi-query cause timeout and  'CALL' query causes hang.

### DIFF
--- a/src/main/java/com/actiontech/dble/server/parser/RwSplitServerParse.java
+++ b/src/main/java/com/actiontech/dble/server/parser/RwSplitServerParse.java
@@ -130,8 +130,8 @@ public final class RwSplitServerParse extends ServerParse {
 
 
     public static boolean isMultiStatement(String sql) {
-        final int index = sql.indexOf(';');
-        return index != -1 && index != sql.length() - 1;
+        int index = ParseUtil.findNextBreak(sql);
+        return index + 1 < sql.length() && !ParseUtil.isEOF(sql, index);
     }
 
     // INSERT' ' | INSTALL '  '

--- a/src/main/java/com/actiontech/dble/server/parser/RwSplitServerParse.java
+++ b/src/main/java/com/actiontech/dble/server/parser/RwSplitServerParse.java
@@ -128,6 +128,12 @@ public final class RwSplitServerParse extends ServerParse {
         return rt;
     }
 
+
+    public static boolean isMultiStatement(String sql) {
+        final int index = sql.indexOf(';');
+        return index != -1 && index != sql.length() - 1;
+    }
+
     // INSERT' ' | INSTALL '  '
     protected static int iCheck(String stmt, int offset) {
         int type = OTHER;

--- a/src/main/java/com/actiontech/dble/services/FrontEndService.java
+++ b/src/main/java/com/actiontech/dble/services/FrontEndService.java
@@ -25,6 +25,7 @@ public abstract class FrontEndService extends VariablesService {
     protected UserName user;
     protected UserConfig userConfig;
     protected final CommandCount commands;
+    protected long clientCapabilities;
 
     public FrontEndService(AbstractConnection connection) {
         super(connection);
@@ -33,6 +34,7 @@ public abstract class FrontEndService extends VariablesService {
 
     public void initFromAuthInfo(AuthResultInfo info) {
         AuthPacket auth = info.getMysqlAuthPacket();
+        clientCapabilities = auth.getClientFlags();
         this.user = new UserName(auth.getUser(), auth.getTenant());
         this.schema = info.getMysqlAuthPacket().getDatabase();
         this.userConfig = info.getUserConfig();
@@ -75,5 +77,9 @@ public abstract class FrontEndService extends VariablesService {
 
     public void setSchema(String schema) {
         this.schema = schema;
+    }
+
+    public long getClientCapabilities() {
+        return clientCapabilities;
     }
 }

--- a/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitHandler.java
+++ b/src/main/java/com/actiontech/dble/services/rwsplit/RWSplitHandler.java
@@ -8,22 +8,35 @@ import com.actiontech.dble.net.connection.AbstractConnection;
 import com.actiontech.dble.net.connection.BackendConnection;
 import com.actiontech.dble.net.mysql.ErrorPacket;
 import com.actiontech.dble.net.mysql.FieldPacket;
+import com.actiontech.dble.net.mysql.OkPacket;
 import com.actiontech.dble.net.mysql.RowDataPacket;
 import com.actiontech.dble.net.service.AbstractService;
 import com.actiontech.dble.services.mysqlsharding.MySQLResponseService;
 import com.actiontech.dble.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.List;
 
 public class RWSplitHandler implements ResponseHandler, LoadDataResponseHandler, PreparedResponseHandler {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RWSplitHandler.class);
     private final RWSplitService rwSplitService;
     private final byte[] originPacket;
     private final AbstractConnection frontedConnection;
     protected volatile ByteBuffer buffer;
+    /**
+    When client send one request. dble should return one and only one response.
+    But , maybe OK event and connection closed event are run in parallel.
+    so we need use synchronized and write2Client to prevent conflict.
+     */
     private boolean write2Client = false;
     private final Callback callback;
+    /**
+    If there are more packets next.This flag in would be set.
+     */
+    private static final int HAS_MORE_RESULTS = 0x08;
 
     public RWSplitHandler(RWSplitService service, byte[] originPacket, Callback callback) {
         this.rwSplitService = service;
@@ -87,15 +100,23 @@ public class RWSplitHandler implements ResponseHandler, LoadDataResponseHandler,
         MySQLResponseService mysqlService = (MySQLResponseService) service;
         boolean executeResponse = mysqlService.syncAndExecute();
         if (executeResponse) {
-            if (callback != null) {
-                callback.callback(true, rwSplitService);
+
+            final OkPacket packet = new OkPacket();
+            packet.read(data);
+            if ((packet.getServerStatus() & HAS_MORE_RESULTS) == 0) {
+                if (callback != null) {
+                    callback.callback(true, rwSplitService);
+                }
+                rwSplitService.getSession().unbindIfSafe();
             }
-            rwSplitService.getSession().unbindIfSafe();
+
             synchronized (this) {
                 if (!write2Client) {
                     data[3] = (byte) rwSplitService.nextPacketId();
                     frontedConnection.write(data);
-                    write2Client = true;
+                    if ((packet.getServerStatus() & HAS_MORE_RESULTS) == 0) {
+                        write2Client = true;
+                    }
                 }
             }
         }
@@ -146,10 +167,19 @@ public class RWSplitHandler implements ResponseHandler, LoadDataResponseHandler,
         synchronized (this) {
             if (!write2Client) {
                 eof[3] = (byte) rwSplitService.nextPacketId();
-                rwSplitService.getSession().unbindIfSafe();
+                if ((eof[7] & HAS_MORE_RESULTS) == 0) {
+                    /*
+                    last resultset will call this
+                     */
+                    rwSplitService.getSession().unbindIfSafe();
+                } else {
+                    LOGGER.debug("Because of multi query had send.It would receive more than one ResultSet. recycle resource should be delayed. client:{}", service);
+                }
                 buffer = frontedConnection.writeToBuffer(eof, buffer);
                 frontedConnection.write(buffer);
-                write2Client = true;
+                if ((eof[7] & HAS_MORE_RESULTS) == 0) {
+                    write2Client = true;
+                }
             }
         }
     }


### PR DESCRIPTION
Reason:  
  In RwSplit scenarios, when using JDBC with URL param `allowMultiQueries`, send multi-query cause timeout.Error reports:`(2013, 'Lost connection to MySQL server during query')`
Type:  
  BUG inner-711
Influences：  
   fixed.


Reason:  
  In RwSplit scenarios, the `CALL` query causes hang.
Type:  
  BUG inner-631
Influences：  
   fixed.
