### PR TITLE
fix: the mysql instance version cannot be lower than the dble version

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
@@ -138,12 +138,10 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
             }
             GetAndSyncDbInstanceKeyVariables task = new GetAndSyncDbInstanceKeyVariables(source, true);
             KeyVariables variables = task.call();
-            int mysqlVersion = Integer.parseInt(variables.getVersion().substring(0, 1));
-            int dbleVersion = Integer.parseInt(SystemConfig.getInstance().getFakeMySQLVersion().substring(0, 1));
             if (variables == null ||
                     variables.isLowerCase() != DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames() ||
                     variables.getMaxPacketSize() < SystemConfig.getInstance().getMaxPacketSize() ||
-                    mysqlVersion < dbleVersion) {
+                    Integer.parseInt(variables.getVersion().substring(0, 1)) < Integer.parseInt(SystemConfig.getInstance().getFakeMySQLVersion().substring(0, 1))) {
                 String url = heartbeat.getSource().getConfig().getUrl();
                 Map<String, String> labels = AlertUtil.genSingleLabel("dbInstance", url);
                 String errMsg;
@@ -151,7 +149,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
                     errMsg = "GetAndSyncDbInstanceKeyVariables failed";
                 } else if (variables.isLowerCase() != DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames()) {
                     errMsg = "this dbInstance[=" + url + "]'s lower_case is wrong";
-                } else if (mysqlVersion < dbleVersion) {
+                } else if (Integer.parseInt(variables.getVersion().substring(0, 1)) < Integer.parseInt(SystemConfig.getInstance().getFakeMySQLVersion().substring(0, 1))) {
                     errMsg = "this dbInstance[=" + url + "]'s version[=" + variables.getVersion() + "] cannot be lower than the dble version[=" + SystemConfig.getInstance().getFakeMySQLVersion() + "]";
                 } else {
                     errMsg = "this dbInstance[=" + url + "]'s max_allowed_packet is " + variables.getMaxPacketSize() + ", but dble's is " + SystemConfig.getInstance().getMaxPacketSize();

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
@@ -138,9 +138,12 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
             }
             GetAndSyncDbInstanceKeyVariables task = new GetAndSyncDbInstanceKeyVariables(source, true);
             KeyVariables variables = task.call();
+            int mysqlVersion = Integer.parseInt(variables.getVersion().substring(0, 1));
+            int dbleVersion = Integer.parseInt(SystemConfig.getInstance().getFakeMySQLVersion().substring(0, 1));
             if (variables == null ||
                     variables.isLowerCase() != DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames() ||
-                    variables.getMaxPacketSize() < SystemConfig.getInstance().getMaxPacketSize()) {
+                    variables.getMaxPacketSize() < SystemConfig.getInstance().getMaxPacketSize() ||
+                    mysqlVersion < dbleVersion) {
                 String url = heartbeat.getSource().getConfig().getUrl();
                 Map<String, String> labels = AlertUtil.genSingleLabel("dbInstance", url);
                 String errMsg;
@@ -148,6 +151,8 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
                     errMsg = "GetAndSyncDbInstanceKeyVariables failed";
                 } else if (variables.isLowerCase() != DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames()) {
                     errMsg = "this dbInstance[=" + url + "]'s lower_case is wrong";
+                } else if (mysqlVersion < dbleVersion) {
+                    errMsg = "this dbInstance[=" + url + "]'s version[=" + variables.getVersion() + "] cannot be lower than the dble version[=" + SystemConfig.getInstance().getFakeMySQLVersion() + "]";
                 } else {
                     errMsg = "this dbInstance[=" + url + "]'s max_allowed_packet is " + variables.getMaxPacketSize() + ", but dble's is " + SystemConfig.getInstance().getMaxPacketSize();
                 }

--- a/src/main/java/com/actiontech/dble/config/helper/GetAndSyncDbInstanceKeyVariables.java
+++ b/src/main/java/com/actiontech/dble/config/helper/GetAndSyncDbInstanceKeyVariables.java
@@ -27,6 +27,7 @@ public class GetAndSyncDbInstanceKeyVariables implements Callable<KeyVariables> 
     private static final String COLUMN_AUTOCOMMIT = "@@autocommit";
     private static final String COLUMN_READONLY = "@@read_only";
     private static final String COLUMN_MAX_PACKET = "@@max_allowed_packet";
+    private static final String COLUMN_VERSION = "@@version";
     private ReentrantLock lock = new ReentrantLock();
     private volatile boolean isFinish = false;
     private Condition finishCond = lock.newCondition();
@@ -51,7 +52,7 @@ public class GetAndSyncDbInstanceKeyVariables implements Callable<KeyVariables> 
         if (columnIsolation == null) {
             return keyVariables;
         }
-        String[] columns = new String[]{COLUMN_LOWER_CASE, COLUMN_AUTOCOMMIT, COLUMN_READONLY, COLUMN_MAX_PACKET, columnIsolation};
+        String[] columns = new String[]{COLUMN_LOWER_CASE, COLUMN_AUTOCOMMIT, COLUMN_READONLY, COLUMN_MAX_PACKET, columnIsolation, COLUMN_VERSION};
         StringBuilder sql = new StringBuilder("select ");
         for (int i = 0; i < columns.length; i++) {
             if (i != 0) {
@@ -107,6 +108,7 @@ public class GetAndSyncDbInstanceKeyVariables implements Callable<KeyVariables> 
                 keyVariables.setMaxPacketSize(Integer.parseInt(result.getResult().get(COLUMN_MAX_PACKET)));
                 keyVariables.setTargetMaxPacketSize(SystemConfig.getInstance().getMaxPacketSize() + KeyVariables.MARGIN_PACKET_SIZE);
                 keyVariables.setReadOnly(result.getResult().get(COLUMN_READONLY).equals("1"));
+                keyVariables.setVersion(result.getResult().get(COLUMN_VERSION));
 
                 if (needSync) {
                     boolean checkNeedSync = false;

--- a/src/main/java/com/actiontech/dble/config/helper/KeyVariables.java
+++ b/src/main/java/com/actiontech/dble/config/helper/KeyVariables.java
@@ -13,6 +13,7 @@ public class KeyVariables {
     private boolean targetAutocommit = true;
     private int targetIsolation = -1;
     private int targetMaxPacketSize = -1;
+    private String version;
 
     private boolean readOnly = false;
     private boolean lowerCase = true;
@@ -81,4 +82,11 @@ public class KeyVariables {
         this.targetMaxPacketSize = targetMaxPacketSize;
     }
 
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
 }

--- a/src/main/java/com/actiontech/dble/config/loader/SystemConfigLoader.java
+++ b/src/main/java/com/actiontech/dble/config/loader/SystemConfigLoader.java
@@ -125,6 +125,10 @@ public final class SystemConfigLoader {
         for (Map.Entry<Object, Object> item : systemDynamic.entrySet()) {
             system.put(item.getKey(), item.getValue());
         }
+        //must be first
+        if (null != system && !StringUtil.isEmpty(system.getProperty("fakeMySQLVersion"))) {
+            systemConfig.setFakeMySQLVersion(system.getProperty("fakeMySQLVersion"));
+        }
         ParameterMapping.mapping(systemConfig, system, StartProblemReporter.getInstance());
         if (system.size() > 0) {
             Set<String> propItem = new HashSet<>();

--- a/src/main/java/com/actiontech/dble/config/util/ConfigUtil.java
+++ b/src/main/java/com/actiontech/dble/config/util/ConfigUtil.java
@@ -199,6 +199,7 @@ public final class ConfigUtil {
             Set<String> firstGroup = new HashSet<>();
             Set<String> secondGroup = new HashSet<>();
             int minNodePacketSize = Integer.MAX_VALUE;
+            int minVersion = Integer.parseInt(SystemConfig.getInstance().getFakeMySQLVersion().substring(0, 1));
             for (Map.Entry<String, Future<KeyVariables>> entry : keyVariablesTaskMap.entrySet()) {
                 String dataSourceName = entry.getKey();
                 Future<KeyVariables> future = entry.getValue();
@@ -212,12 +213,17 @@ public final class ConfigUtil {
                         secondGroup.add(dataSourceName);
                     }
                     minNodePacketSize = minNodePacketSize < keyVariables.getMaxPacketSize() ? minNodePacketSize : keyVariables.getMaxPacketSize();
+                    int version = Integer.parseInt(keyVariables.getVersion().substring(0, 1));
+                    minVersion = minVersion < version ? minVersion : version;
                 }
             }
             if (minNodePacketSize < SystemConfig.getInstance().getMaxPacketSize() + KeyVariables.MARGIN_PACKET_SIZE) {
                 SystemConfig.getInstance().setMaxPacketSize(minNodePacketSize - KeyVariables.MARGIN_PACKET_SIZE);
                 msg = "dble's maxPacketSize will be set to (the min of all dbGroup's max_allowed_packet) - " + KeyVariables.MARGIN_PACKET_SIZE + ":" + (minNodePacketSize - KeyVariables.MARGIN_PACKET_SIZE);
                 LOGGER.warn(msg);
+            }
+            if (minVersion < Integer.parseInt(SystemConfig.getInstance().getFakeMySQLVersion().substring(0, 1))) {
+                throw new ConfigException("the dble version[=" + SystemConfig.getInstance().getFakeMySQLVersion() + "] cannot be higher than the minimum version of the backend mysql node,pls check the backend mysql node.");
             }
             if (secondGroup.size() != 0) {
                 // if all datasoure's lower case are not equal, throw exception


### PR DESCRIPTION
Reason:  
  BUG inner 647
Type:  
  BUG
Influences：  
the mysql instance version cannot be lower than the dble version
the charsetutil reference does not work due to the timing of fakeMySQLVersion value assignment
