### PR TITLE
fix: when connecting, the client_found_rows value of the client and dble are inconsistent, the log will prompt(cherry pick from master #2413)

### DIFF
--- a/src/main/java/com/actiontech/dble/services/mysqlauthenticate/MySQLFrontAuthService.java
+++ b/src/main/java/com/actiontech/dble/services/mysqlauthenticate/MySQLFrontAuthService.java
@@ -6,6 +6,7 @@ import com.actiontech.dble.config.Capabilities;
 import com.actiontech.dble.config.ErrorCode;
 import com.actiontech.dble.config.Versions;
 import com.actiontech.dble.config.model.SystemConfig;
+import com.actiontech.dble.config.model.user.ManagerUserConfig;
 import com.actiontech.dble.config.model.user.UserConfig;
 import com.actiontech.dble.config.model.user.UserName;
 import com.actiontech.dble.net.connection.AbstractConnection;
@@ -15,6 +16,7 @@ import com.actiontech.dble.net.service.AuthResultInfo;
 import com.actiontech.dble.net.service.AuthService;
 import com.actiontech.dble.services.factorys.BusinessServiceFactory;
 import com.actiontech.dble.services.mysqlauthenticate.util.AuthUtil;
+import com.actiontech.dble.singleton.CapClientFoundRows;
 import com.actiontech.dble.singleton.TraceManager;
 import com.actiontech.dble.util.RandomUtil;
 import org.slf4j.Logger;
@@ -187,6 +189,10 @@ public class MySQLFrontAuthService extends AuthService {
         String errMsg = AuthUtil.auth(new UserName(authPacket.getUser(), authPacket.getTenant()), connection, seed, authPacket.getPassword(), authPacket.getDatabase(), pluginName, authPacket.getClientFlags());
         UserConfig userConfig = DbleServer.getInstance().getConfig().getUsers().get(new UserName(authPacket.getUser(), authPacket.getTenant()));
         checkForResult(new AuthResultInfo(errMsg, authPacket, userConfig));
+        boolean isFoundRows = Capabilities.CLIENT_FOUND_ROWS == (Capabilities.CLIENT_FOUND_ROWS & authPacket.getClientFlags());
+        if (!(userConfig instanceof ManagerUserConfig) && isFoundRows != CapClientFoundRows.getInstance().isEnableCapClientFoundRows()) {
+            LOGGER.warn("the client requested CLIENT_FOUND_ROWS capabilities is '{}', dble is configured as '{}',pls set the same.", isFoundRows ? "found rows" : "affect rows", CapClientFoundRows.getInstance().isEnableCapClientFoundRows() ? "found rows" : "affect rows");
+        }
     }
 
     private int getServerCapabilities() {

--- a/src/main/java/com/actiontech/dble/services/mysqlauthenticate/util/AuthUtil.java
+++ b/src/main/java/com/actiontech/dble/services/mysqlauthenticate/util/AuthUtil.java
@@ -1,12 +1,11 @@
 /*
- * Copyright (C) 2016-2020 ActionTech.
+ * Copyright (C) 2016-2021 ActionTech.
  * License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher.
  */
 
 package com.actiontech.dble.services.mysqlauthenticate.util;
 
 import com.actiontech.dble.DbleServer;
-import com.actiontech.dble.config.Capabilities;
 import com.actiontech.dble.config.ErrorCode;
 import com.actiontech.dble.config.model.user.ManagerUserConfig;
 import com.actiontech.dble.config.model.user.ShardingUserConfig;
@@ -17,7 +16,6 @@ import com.actiontech.dble.net.connection.FrontendConnection;
 import com.actiontech.dble.services.manager.information.ManagerSchemaInfo;
 import com.actiontech.dble.services.mysqlauthenticate.PluginName;
 import com.actiontech.dble.services.mysqlauthenticate.SecurityUtil;
-import com.actiontech.dble.singleton.CapClientFoundRows;
 import com.actiontech.dble.singleton.FrontendUserManager;
 import com.actiontech.dble.singleton.TraceManager;
 import com.actiontech.dble.util.IPAddressUtil;
@@ -72,9 +70,7 @@ public final class AuthUtil {
                         break;
                 }
 
-                if ((Capabilities.CLIENT_FOUND_ROWS == (Capabilities.CLIENT_FOUND_ROWS & clientFlags)) != CapClientFoundRows.getInstance().isEnableCapClientFoundRows()) {
-                    return "The client requested CLIENT_FOUND_ROWS capabilities does not match, in the manager use show @@cap_client_found_rows check latest status.";
-                }
+
             } else if (userConfig instanceof ManagerUserConfig) {
                 switch (checkManagerSchema(schema)) {
                     case ErrorCode.ER_BAD_DB_ERROR:


### PR DESCRIPTION
Reason:
  Improve inner-814
Type:
  Improve
Influences：
   fix: when connecting, the client_found_rows value of the client and dble are inconsistent, the log will prompt
#2413 