### PR TITLE
fix: synchronously modify the value of dbGroup_status in the configuration center during reload

### DIFF
--- a/src/main/java/com/actiontech/dble/cluster/ClusterHelper.java
+++ b/src/main/java/com/actiontech/dble/cluster/ClusterHelper.java
@@ -60,6 +60,7 @@ public final class ClusterHelper {
         ClusterLogic.syncDbJsonToCluster();
         ClusterLogic.syncShardingJsonToCluster();
         ClusterLogic.syncUseJsonToCluster();
+        ClusterLogic.syncDbGroupStatusToCluster();
     }
 
     public static String getPathValue(String path) throws Exception {

--- a/src/main/java/com/actiontech/dble/cluster/ClusterLogic.java
+++ b/src/main/java/com/actiontech/dble/cluster/ClusterLogic.java
@@ -435,7 +435,8 @@ public final class ClusterLogic {
         if (lock != null && SystemConfig.getInstance().getInstanceName().equals(lock) && !isWriteToLocal) {
             return;
         }
-        if (!StringUtil.isEmpty(sequenceConfig)) {
+        boolean loadByCluster = ClusterConfig.getInstance().getSequenceHandlerType() == ClusterConfig.SEQUENCE_HANDLER_MYSQL || ClusterConfig.getInstance().getSequenceHandlerType() == ClusterConfig.SEQUENCE_HANDLER_ZK_GLOBAL_INCREMENT;
+        if (loadByCluster && !StringUtil.isEmpty(sequenceConfig)) {
             SequenceConverter sequenceConverter = new SequenceConverter();
             Properties props = sequenceConverter.jsonToProperties(sequenceConfig);
             PropertiesUtil.storeProps(props, sequenceConverter.getFileName());


### PR DESCRIPTION
Reason:  
  BUG inner-878
Type:  
  BUG
Influences：  
fix: synchronously modify the value of dbGroup_status in the configuration center during reload
sequence persistence increases judgment
