### PR TITLE
fix that set statement that contains `.` doesn't work, eg: set @.abc_123$=8

### DIFF
--- a/src/main/java/com/actiontech/dble/server/handler/SetHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/SetHandler.java
@@ -153,7 +153,7 @@ public final class SetHandler {
             if (owner.isGlobal()) {
                 throw new SQLSyntaxErrorException("unsupport global");
             }
-            return target.getName();
+            return target.toString();
         } else if (key instanceof SQLVariantRefExpr) {
             SQLVariantRefExpr target = (SQLVariantRefExpr) key;
             if (target.isGlobal()) {


### PR DESCRIPTION
Reason:  
  BUG #inner-889. 
Type:  
  BUG
Influences：  
  fix that set statement that contains `.` doesn't work, eg: set @.abc_123$=8
