### PR TITLE
fix: Zookeeper 3.4.13 or higher version causes startup error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.14</version>
+            <version>3.4.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Reason:  
  BUG 
Type:  
  BUG
Influences：  
fix: Zookeeper 3.4.13 or higher version causes startup error
