### PR TITLE
fix: table name was not resolved in the hint sql(cherry pick from 3.21.02.99)

### DIFF
--- a/src/main/java/com/actiontech/dble/services/manager/information/ManagerTableUtil.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/ManagerTableUtil.java
@@ -19,6 +19,7 @@ import com.actiontech.dble.plan.common.item.Item;
 import com.actiontech.dble.plan.common.item.ItemField;
 import com.actiontech.dble.plan.visitor.MySQLItemVisitor;
 import com.actiontech.dble.services.manager.ManagerService;
+import com.actiontech.dble.singleton.RouteService;
 import com.actiontech.dble.util.StringUtil;
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
@@ -124,6 +125,13 @@ public final class ManagerTableUtil {
     }
 
     public static List<String> getTables(String defaultSchema, String sql) {
+        int hintLength = RouteService.isHintSql(sql);
+        if (hintLength != -1) {
+            int endPos = sql.substring(hintLength).indexOf("*/") + hintLength;
+            if (endPos > 0) {
+                sql = sql.substring(endPos + "*/".length()).trim();
+            }
+        }
         SQLStatementParser parser = new MySqlStatementParser(sql);
         SQLStatement sqlStatement = parser.parseStatement();
         MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();

--- a/src/test/java/com/actiontech/dble/util/ManagerTableTest.java
+++ b/src/test/java/com/actiontech/dble/util/ManagerTableTest.java
@@ -1,0 +1,42 @@
+package com.actiontech.dble.util;
+
+import com.actiontech.dble.services.manager.information.ManagerTableUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ManagerTableTest {
+
+    @Test
+    public void check() {
+        List<String> realList = ManagerTableUtil.getTables("schema", "select * from test");
+        Assert.assertEquals("schema.test", realList.get(0));
+
+        realList = ManagerTableUtil.getTables("schema", "select * from testdb.test");
+        Assert.assertEquals("testdb.test", realList.get(0));
+
+        realList = ManagerTableUtil.getTables("schema", "select * from `testdb`.`test`");
+        Assert.assertEquals("testdb.test", realList.get(0));
+
+        realList = ManagerTableUtil.getTables("schema", "select * from `testdb`.test inner join test1");
+        Assert.assertEquals("testdb.test", realList.get(0));
+        Assert.assertEquals("schema.test1", realList.get(1));
+
+
+        realList = ManagerTableUtil.getTables("schema", "/*!dble:shardingNode=dn1*/ select n.id,s.name from sharding_2_t1 n join sharding_4_t1 s on n.id=s.id ");
+        Assert.assertEquals("schema.sharding_2_t1", realList.get(0));
+        Assert.assertEquals("schema.sharding_4_t1", realList.get(1));
+
+        realList = ManagerTableUtil.getTables("schema", "/*#dble:sharding=DN1*/select n.id,s.name from sharding_2_t1 n join sharding_4_t1 s on n.id=s.id ");
+        Assert.assertEquals("schema.sharding_2_t1", realList.get(0));
+        Assert.assertEquals("schema.sharding_4_t1", realList.get(1));
+
+        realList = ManagerTableUtil.getTables("schema", "/*#dble:sql = SELECT id FROM user*/select n.id,s.name from sharding_2_t1 n join sharding_4_t1 s on n.id=s.id ");
+        Assert.assertEquals("schema.sharding_2_t1", realList.get(0));
+        Assert.assertEquals("schema.sharding_4_t1", realList.get(1));
+
+        realList = ManagerTableUtil.getTables("schema", "select n.id,s.name from sharding_2_t1 n join sharding_2_t1 s on n.id=s.id ");
+        Assert.assertEquals(2, realList.size());
+    }
+}


### PR DESCRIPTION
Reason:  
  BUG inner 1051
Type:  
  BUG
Influences：  
   fix: table name was not resolved in the hint sql(cherry pick from 3.21.02.99)
