### PR TITLE
fix:complex queries including sub-queries do not need to be optimized for single node delivery

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
@@ -89,10 +89,6 @@ public abstract class BaseHandlerBuilder {
         return subQueryBuilderList;
     }
 
-    public boolean isContainSubQuery() {
-        return node.getSubQueries().size() > 0;
-    }
-
     /**
      * generate a handler chain
      */
@@ -537,5 +533,14 @@ public abstract class BaseHandlerBuilder {
 
     public boolean isExistView() {
         return subQueryBuilderList.stream().anyMatch(BaseHandlerBuilder::isExistView) || node.isExistView();
+    }
+
+
+    public boolean isContainSubQuery(PlanNode node) {
+        return node.getSubQueries().size() > 0 || node.getChildren().stream().anyMatch(this::isContainSubQuery);
+    }
+
+    public PlanNode getNode() {
+        return node;
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
@@ -59,7 +59,7 @@ public abstract class BaseHandlerBuilder {
     protected DMLResponseHandler start;
     /* the current last handler */
     private DMLResponseHandler currentLast;
-    private PlanNode node;
+    private final PlanNode node;
     Map<String, SchemaConfig> schemaConfigMap = new HashMap<>();
     /* the children can be push down */
     boolean canPushDown = false;
@@ -68,8 +68,8 @@ public abstract class BaseHandlerBuilder {
     /* has where handler */
     boolean needWhereHandler = true;
 
-    protected boolean isExplain = false;
-    private List<BaseHandlerBuilder> subQueryBuilderList = new CopyOnWriteArrayList<>();
+    protected boolean isExplain;
+    private final List<BaseHandlerBuilder> subQueryBuilderList = new CopyOnWriteArrayList<>();
 
     protected BaseHandlerBuilder(NonBlockingSession session, PlanNode node, HandlerBuilder hBuilder, boolean isExplain) {
         this.session = session;
@@ -338,8 +338,7 @@ public abstract class BaseHandlerBuilder {
         if (jn.isLeftOrderMatch()) {
             List<Order> leftChildOrders = jn.getLeftNode().getOrderBys();
             List<Order> leftRemainOrders = leftChildOrders.subList(leftOnOrders.size(), leftChildOrders.size());
-            if (PlanUtil.orderContains(leftRemainOrders, pushedOrders))
-                return true;
+            return PlanUtil.orderContains(leftRemainOrders, pushedOrders);
         }
         return false;
     }
@@ -483,37 +482,31 @@ public abstract class BaseHandlerBuilder {
 
     private void handleSubQuery(final ReentrantLock lock, final Condition finishSubQuery, final AtomicBoolean finished,
                                 final AtomicInteger subNodes, final CopyOnWriteArrayList<ErrorPacket> errorPackets, final PlanNode planNode, final SubQueryHandler tempHandler) {
-        DbleServer.getInstance().getComplexQueryExecutor().execute(new Runnable() {
-            @Override
-            public void run() {
-                boolean startHandler = false;
-                try {
-                    BaseHandlerBuilder builder = hBuilder.getBuilder(session, planNode, false);
-                    DMLResponseHandler endHandler = builder.getEndHandler();
-                    endHandler.setNextHandler(tempHandler);
-                    getSubQueryBuilderList().add(builder);
-                    CallBackHandler tempDone = new CallBackHandler() {
-                        @Override
-                        public void call() throws Exception {
-                            if (tempHandler.getErrorPacket() != null) {
-                                errorPackets.add(tempHandler.getErrorPacket());
-                            }
-                            subQueryFinished(subNodes, lock, finished, finishSubQuery);
-                        }
-                    };
-                    tempHandler.setTempDoneCallBack(tempDone);
-                    startHandler = true;
-                    HandlerBuilder.startHandler(endHandler);
-                } catch (Exception e) {
-                    LOGGER.info("execute ItemScalarSubQuery error", e);
-                    ErrorPacket errorPackage = new ErrorPacket();
-                    errorPackage.setErrNo(ErrorCode.ER_UNKNOWN_ERROR);
-                    String errorMsg = e.getMessage() == null ? e.toString() : e.getMessage();
-                    errorPackage.setMessage(errorMsg.getBytes(StandardCharsets.UTF_8));
-                    errorPackets.add(errorPackage);
-                    if (!startHandler) {
-                        subQueryFinished(subNodes, lock, finished, finishSubQuery);
+        DbleServer.getInstance().getComplexQueryExecutor().execute(() -> {
+            boolean startHandler = false;
+            try {
+                BaseHandlerBuilder builder = hBuilder.getBuilder(session, planNode, false);
+                DMLResponseHandler endHandler = builder.getEndHandler();
+                endHandler.setNextHandler(tempHandler);
+                getSubQueryBuilderList().add(builder);
+                CallBackHandler tempDone = () -> {
+                    if (tempHandler.getErrorPacket() != null) {
+                        errorPackets.add(tempHandler.getErrorPacket());
                     }
+                    subQueryFinished(subNodes, lock, finished, finishSubQuery);
+                };
+                tempHandler.setTempDoneCallBack(tempDone);
+                startHandler = true;
+                HandlerBuilder.startHandler(endHandler);
+            } catch (Exception e) {
+                LOGGER.info("execute ItemScalarSubQuery error", e);
+                ErrorPacket errorPackage = new ErrorPacket();
+                errorPackage.setErrNo(ErrorCode.ER_UNKNOWN_ERROR);
+                String errorMsg = e.getMessage() == null ? e.toString() : e.getMessage();
+                errorPackage.setMessage(errorMsg.getBytes(StandardCharsets.UTF_8));
+                errorPackets.add(errorPackage);
+                if (!startHandler) {
+                    subQueryFinished(subNodes, lock, finished, finishSubQuery);
                 }
             }
         });
@@ -536,8 +529,8 @@ public abstract class BaseHandlerBuilder {
     }
 
 
-    public boolean isContainSubQuery(PlanNode node) {
-        return node.getSubQueries().size() > 0 || node.getChildren().stream().anyMatch(this::isContainSubQuery);
+    public boolean isContainSubQuery(PlanNode planNode) {
+        return planNode.getSubQueries().size() > 0 || planNode.getChildren().stream().anyMatch(this::isContainSubQuery);
     }
 
     public PlanNode getNode() {

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/BaseHandlerBuilder.java
@@ -89,6 +89,10 @@ public abstract class BaseHandlerBuilder {
         return subQueryBuilderList;
     }
 
+    public boolean isContainSubQuery() {
+        return node.getSubQueries().size() > 0;
+    }
+
     /**
      * generate a handler chain
      */
@@ -320,7 +324,6 @@ public abstract class BaseHandlerBuilder {
 
     /**
      * the order way of join node stored in left join on orders and right join on orders
-     *
      */
     private boolean isJoinNodeOrderMatch(JoinNode jn, List<Order> orderBys) {
         // onCondition column in orderBys will be saved to onOrders,
@@ -353,7 +356,6 @@ public abstract class BaseHandlerBuilder {
 
     /**
      * try to merger the order of 'order by' syntax to columnsSelected
-     *
      */
     private List<Order> mergeOrderBy(List<Item> columnsSelected, List<Order> orderBys) {
         List<Integer> orderIndexes = new ArrayList<>();

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/HandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/HandlerBuilder.java
@@ -89,7 +89,7 @@ public class HandlerBuilder {
                 }
             }
             session.endComplexRoute();
-            if (!builder.isExistView() && !builder.isContainSubQuery()) {
+            if (!builder.isExistView() && !builder.isContainSubQuery(builder.getNode())) {
                 List<DMLResponseHandler> merges = Lists.newArrayList(builder.getEndHandler().getMerges());
                 List<BaseHandlerBuilder> subQueryBuilderList = builder.getSubQueryBuilderList();
                 subQueryBuilderList.stream().map(baseHandlerBuilder -> baseHandlerBuilder.getEndHandler().getMerges()).forEach(merges::addAll);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/HandlerBuilder.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/builder/HandlerBuilder.java
@@ -89,7 +89,7 @@ public class HandlerBuilder {
                 }
             }
             session.endComplexRoute();
-            if (!builder.isExistView()) {
+            if (!builder.isExistView() && !builder.isContainSubQuery()) {
                 List<DMLResponseHandler> merges = Lists.newArrayList(builder.getEndHandler().getMerges());
                 List<BaseHandlerBuilder> subQueryBuilderList = builder.getSubQueryBuilderList();
                 subQueryBuilderList.stream().map(baseHandlerBuilder -> baseHandlerBuilder.getEndHandler().getMerges()).forEach(merges::addAll);

--- a/src/main/java/com/actiontech/dble/server/handler/ExplainHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ExplainHandler.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (C) 2016-2021 ActionTech.
-* based on code by MyCATCopyrightHolder Copyright (c) 2013, OpenCloudDB/MyCAT.
-* License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher.
-*/
+ * Copyright (C) 2016-2021 ActionTech.
+ * based on code by MyCATCopyrightHolder Copyright (c) 2013, OpenCloudDB/MyCAT.
+ * License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher.
+ */
 package com.actiontech.dble.server.handler;
 
 import com.actiontech.dble.DbleServer;
@@ -229,7 +229,7 @@ public final class ExplainHandler {
         } else {
             BaseHandlerBuilder builder = buildNodes(rrs, service);
             String routeNode = null;
-            if (!builder.isExistView()) {
+            if (!builder.isExistView() && !builder.isContainSubQuery()) {
                 List<DMLResponseHandler> merges = Lists.newArrayList(builder.getEndHandler().getMerges());
                 List<BaseHandlerBuilder> subQueryBuilderList = builder.getSubQueryBuilderList();
                 subQueryBuilderList.stream().map(baseHandlerBuilder -> baseHandlerBuilder.getEndHandler().getMerges()).forEach(merges::addAll);

--- a/src/main/java/com/actiontech/dble/server/handler/ExplainHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ExplainHandler.java
@@ -229,7 +229,7 @@ public final class ExplainHandler {
         } else {
             BaseHandlerBuilder builder = buildNodes(rrs, service);
             String routeNode = null;
-            if (!builder.isExistView() && !builder.isContainSubQuery()) {
+            if (!builder.isExistView() && !builder.isContainSubQuery(builder.getNode())) {
                 List<DMLResponseHandler> merges = Lists.newArrayList(builder.getEndHandler().getMerges());
                 List<BaseHandlerBuilder> subQueryBuilderList = builder.getSubQueryBuilderList();
                 subQueryBuilderList.stream().map(baseHandlerBuilder -> baseHandlerBuilder.getEndHandler().getMerges()).forEach(merges::addAll);


### PR DESCRIPTION
Reason:  
  BUG inner-1119
Type:  
  BUG
Influences：  
fix:complex queries including sub-queries do not need to be optimized for single node delivery
eg:select count(*) from sharding_4_t1 where id =(select id from sharding_4_t1 where id=1)
