### PR TITLE
inner-1154: reload config should succeed if cluster meta is empty

### DIFF
--- a/src/main/java/com/actiontech/dble/cluster/logic/AbstractClusterLogic.java
+++ b/src/main/java/com/actiontech/dble/cluster/logic/AbstractClusterLogic.java
@@ -51,6 +51,9 @@ public class AbstractClusterLogic extends GeneralClusterLogic {
     }
 
     public boolean checkResponseForOneTime(String path, Map<String, OnlineType> expectedMap, @Nonnull StringBuilder errorMsg) {
+        if (expectedMap.size() == 0) {
+            return true;
+        }
         Map<String, OnlineType> currentMap = ClusterHelper.getOnlineMap();
         checkOnline(expectedMap, currentMap);
         List<ClusterEntry<FeedBackType>> responseList;


### PR DESCRIPTION
Signed-off-by: dcy <dcy10000@gmail.com>

Reason:  
  BUG inner-1154: reload config should succeed if cluster meta is empty
Type:  
  BUG
Influences：  
   cluster waiting
