### PR TITLE
fix: when a connection exits directly in a transaction, the statistics table accidentally loses the transaction

### DIFF
--- a/src/main/java/com/actiontech/dble/net/connection/AbstractConnection.java
+++ b/src/main/java/com/actiontech/dble/net/connection/AbstractConnection.java
@@ -143,7 +143,7 @@ public abstract class AbstractConnection implements Connection {
         if (isClosed.compareAndSet(false, true)) {
             if (service instanceof BusinessService)
                 ((BusinessService) service).transactionsCountInTx();
-            Optional.ofNullable(StatisticListener.getInstance().getRecorder(service)).ifPresent(r -> r.onTxEndByExit());
+            Optional.ofNullable(StatisticListener.getInstance().getRecorder(service)).ifPresent(r -> r.onExit(reason));
             StatisticListener.getInstance().remove(service);
             closeSocket();
             LOGGER.info("connection id close for reason " + reason + " with connection " + toString());

--- a/src/main/java/com/actiontech/dble/statistic/sql/StatisticDisruptor.java
+++ b/src/main/java/com/actiontech/dble/statistic/sql/StatisticDisruptor.java
@@ -74,16 +74,19 @@ public class StatisticDisruptor {
         @Override
         public void handleEventException(Throwable ex, long sequence, Object event) {
             LOGGER.warn("Exception processing: {} {} ,exception：{}", sequence, event, ex);
+            ex.printStackTrace();
         }
 
         @Override
         public void handleOnStartException(Throwable ex) {
             LOGGER.error("Exception during onStart for statistic's disruptor ,exception：{}", ex);
+            ex.printStackTrace();
         }
 
         @Override
         public void handleOnShutdownException(Throwable ex) {
             LOGGER.error("Exception during onShutdown for statistic's disruptor ,exception：{}", ex);
+            ex.printStackTrace();
         }
     }
 }

--- a/src/main/java/com/actiontech/dble/statistic/sql/StatisticRecord.java
+++ b/src/main/java/com/actiontech/dble/statistic/sql/StatisticRecord.java
@@ -54,18 +54,29 @@ public class StatisticRecord {
     public void onTxEnd() {
     }
 
-    public void onTxEndByExit() {
+    public void onExit(String reason) {
+        long txEndTime = System.nanoTime();
         if (isStartTx && txEntry != null) {
-            long txEndTime = System.nanoTime();
             isStartTx = false;
-            frontendSqlEntry = new StatisticFrontendSqlEntry(frontendInfo, txEndTime);
-            frontendSqlEntry.setSql("exit");
-            frontendSqlEntry.setAllEndTime(txEndTime);
-            frontendSqlEntry.setXaId(xaId);
-            frontendSqlEntry.setTxId(txid);
-            txEntry.add(frontendSqlEntry);
+            if (reason.contains("quit cmd")) {
+                StatisticFrontendSqlEntry f = new StatisticFrontendSqlEntry(frontendInfo, txEndTime);
+                f.setSql("exit");
+                f.setAllEndTime(txEndTime);
+                f.setXaId(xaId);
+                f.setTxId(txid);
+                txEntry.add(f);
+            }
             txEntry.setAllEndTime(txEndTime);
             pushTx();
+        } else {
+            if (!reason.contains("quit cmd")) return;
+            StatisticFrontendSqlEntry f = new StatisticFrontendSqlEntry(frontendInfo, txEndTime);
+            f.setSql("exit");
+            f.setAllEndTime(txEndTime);
+            f.setXaId(xaId);
+            f.setTxId(txid);
+            f.setNeedToTx(true);
+            pushFrontendSql();
         }
     }
 

--- a/src/main/java/com/actiontech/dble/statistic/sql/handler/SqlStatisticHandler.java
+++ b/src/main/java/com/actiontech/dble/statistic/sql/handler/SqlStatisticHandler.java
@@ -47,7 +47,11 @@ public class SqlStatisticHandler implements StatisticDataHandler {
                 if (txRecords.size() >= StatisticManager.getInstance().getSqlLogSize()) {
                     txRecords.pollFirstEntry();
                 }
-                txRecords.put(frontendSqlEntry.getTxId(), new TxRecord(frontendSqlEntry));
+                if (null == txRecords.get(frontendSqlEntry.getTxId())) {
+                    txRecords.put(frontendSqlEntry.getTxId(), new TxRecord(frontendSqlEntry));
+                } else {
+                    txRecords.get(frontendSqlEntry.getTxId()).getSqls().add(new SQLRecord(frontendSqlEntry));
+                }
             }
         }
     }
@@ -106,7 +110,7 @@ public class SqlStatisticHandler implements StatisticDataHandler {
             this.startTime = frontendSqlEntry.getStartTime();
             this.info = frontendSqlEntry.getFrontend();
             this.duration = frontendSqlEntry.getDuration();
-            this.sqls = new ArrayList<>(1);
+            this.sqls = new ArrayList<>(2);
             this.sqls.add(new SQLRecord(frontendSqlEntry));
         }
 


### PR DESCRIPTION
…s table accidentally loses the transaction

Reason:  
  BUG inner 1186
Type:  
  BUG
Influences：  
   fix: when a connection exits directly in a transaction, the statistics table accidentally loses the transaction
