### PR TITLE
inner-940:avoid that backend connection is closed before setting ResponseHandler to backend connection

### DIFF
--- a/src/main/java/com/actiontech/dble/services/mysqlsharding/MySQLResponseService.java
+++ b/src/main/java/com/actiontech/dble/services/mysqlsharding/MySQLResponseService.java
@@ -302,6 +302,9 @@ public class MySQLResponseService extends BackendService {
 
     // send query
     public void sendQueryCmd(String query, CharsetNames clientCharset) {
+        if (connection.isClosed()) {
+            onConnectionClose("connection is closed before sending cmd");
+        }
         CommandPacket packet = new CommandPacket();
         packet.setPacketId(0);
         packet.setCommand(MySQLPacket.COM_QUERY);
@@ -411,6 +414,9 @@ public class MySQLResponseService extends BackendService {
     }
 
     private WriteToBackendTask sendQueryCmdTask(String query, CharsetNames clientCharset) {
+        if (connection.isClosed()) {
+            onConnectionClose("connection is closed before sending cmd");
+        }
         CommandPacket packet = new CommandPacket();
         packet.setPacketId(0);
         packet.setCommand(MySQLPacket.COM_QUERY);


### PR DESCRIPTION
Reason:  
  BUG inner#940.
Type:  
  BUG
Influences：  
  avoid that backend connection is closed before setting ResponseHandler to backend connection
