### PR TITLE
inner-1239:avoid thread remaining for group by

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/groupby/DirectGroupByHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/query/impl/groupby/DirectGroupByHandler.java
@@ -117,6 +117,8 @@ public class DirectGroupByHandler extends OwnThreadDMLHandler {
                 localResultReferredSums, this.isAllPushDown(), charSet).
                 setMemSizeController(session.getOtherBufferMC());
         for (int i = 0; i < bucketSize; i++) {
+            if (terminate.get())
+                break;
             RowDataComparator tmpComparator = new RowDataComparator(this.localResultFps, this.groupBys,
                     this.isAllPushDown(), this.type());
             GroupByBucket bucket = new GroupByBucket(queue, outQueue, pool, localResultFps.size(), tmpComparator,


### PR DESCRIPTION
Reason:  
  BUG #1239.  
Type:  
  BUG
Influences：  
  avoid thread remaining for group by
