### PR TITLE
inner-1253: make sure XmlSchemaLoader read the newest data of HA when use reload

### DIFF
--- a/src/main/java/com/actiontech/dble/btrace/provider/ClusterDelayProvider.java
+++ b/src/main/java/com/actiontech/dble/btrace/provider/ClusterDelayProvider.java
@@ -17,6 +17,11 @@ public final class ClusterDelayProvider {
 
     }
 
+    public static void delayBeforeUploadHa() {
+
+    }
+
+
     public static void delayAfterViewSetKey() {
 
     }

--- a/src/main/java/com/actiontech/dble/cluster/response/DataHostHaResponse.java
+++ b/src/main/java/com/actiontech/dble/cluster/response/DataHostHaResponse.java
@@ -2,6 +2,7 @@ package com.actiontech.dble.cluster.response;
 
 import com.actiontech.dble.DbleServer;
 import com.actiontech.dble.backend.datasource.PhysicalDataHost;
+import com.actiontech.dble.btrace.provider.ClusterDelayProvider;
 import com.actiontech.dble.cluster.ClusterHelper;
 import com.actiontech.dble.cluster.ClusterParamCfg;
 import com.actiontech.dble.cluster.ClusterPathUtil;
@@ -74,6 +75,7 @@ public class DataHostHaResponse implements ClusterXmlLoader {
     @Override
     public void notifyCluster() throws Exception {
         HaConfigManager.getInstance().init();
+        ClusterDelayProvider.delayBeforeUploadHa();
         Map<String, String> map = HaConfigManager.getInstance().getSourceJsonList();
         for (Map.Entry<String, String> entry : map.entrySet()) {
             ClusterHelper.setKV(ClusterPathUtil.getHaStatusPath(entry.getKey()), entry.getValue());

--- a/src/main/java/com/actiontech/dble/cluster/xmltoKv/XmltoCluster.java
+++ b/src/main/java/com/actiontech/dble/cluster/xmltoKv/XmltoCluster.java
@@ -36,6 +36,9 @@ public final class XmltoCluster {
 
         new XmlServerLoader(xmlProcess, ucoreListen);
 
+        //must before upload db data
+        new DataHostHaResponse().notifyCluster();
+
         new XmlSchemaLoader(xmlProcess, ucoreListen);
 
         new XmlEhcachesLoader(xmlProcess, ucoreListen);
@@ -46,7 +49,7 @@ public final class XmltoCluster {
 
         xmlProcess.initJaxbClass();
         ucoreListen.initAllNode();
-        new DataHostHaResponse().notifyCluster();
+
     }
 
 }

--- a/src/main/java/com/actiontech/dble/config/loader/zkprocess/xmltozk/XmltoZkMain.java
+++ b/src/main/java/com/actiontech/dble/config/loader/zkprocess/xmltozk/XmltoZkMain.java
@@ -42,6 +42,12 @@ public final class XmltoZkMain {
 
         XmlProcessBase xmlProcess = new XmlProcessBase();
 
+
+        if (DbleServer.getInstance().isUseOuterHa()) {
+            //must before upload db data
+            new DataHostStatusTozkLoader(zkListen, zkConn);
+        }
+
         // xmltozk for schema
         new SchemasxmlTozkLoader(zkListen, zkConn, xmlProcess);
 
@@ -51,9 +57,6 @@ public final class XmltoZkMain {
         // xmltozk for rule
         new RulesxmlTozkLoader(zkListen, zkConn, xmlProcess);
 
-        if (DbleServer.getInstance().isUseOuterHa()) {
-            new DataHostStatusTozkLoader(zkListen, zkConn);
-        }
 
         xmlProcess.initJaxbClass();
 
@@ -72,6 +75,9 @@ public final class XmltoZkMain {
 
         XmlProcessBase xmlProcess = new XmlProcessBase();
 
+        //must before upload db data
+        new DataHostStatusTozkLoader(zkListen, zkConn);
+
         new SchemasxmlTozkLoader(zkListen, zkConn, xmlProcess);
 
         new ServerxmlTozkLoader(zkListen, zkConn, xmlProcess);
@@ -84,7 +90,6 @@ public final class XmltoZkMain {
 
         new OthermsgTozkLoader(zkListen, zkConn);
 
-        new DataHostStatusTozkLoader(zkListen, zkConn);
 
         xmlProcess.initJaxbClass();
 

--- a/src/main/java/com/actiontech/dble/config/loader/zkprocess/xmltozk/listen/DataHostStatusTozkLoader.java
+++ b/src/main/java/com/actiontech/dble/config/loader/zkprocess/xmltozk/listen/DataHostStatusTozkLoader.java
@@ -1,5 +1,6 @@
 package com.actiontech.dble.config.loader.zkprocess.xmltozk.listen;
 
+import com.actiontech.dble.btrace.provider.ClusterDelayProvider;
 import com.actiontech.dble.config.loader.zkprocess.comm.NotifyService;
 import com.actiontech.dble.config.loader.zkprocess.comm.ZookeeperProcessListen;
 import com.actiontech.dble.config.loader.zkprocess.zookeeper.process.ZkMultiLoader;
@@ -25,6 +26,7 @@ public class DataHostStatusTozkLoader extends ZkMultiLoader implements NotifySer
     @Override
     public boolean notifyProcess() throws Exception {
         HaConfigManager.getInstance().init();
+        ClusterDelayProvider.delayBeforeUploadHa();
         Map<String, String> map = HaConfigManager.getInstance().getSourceJsonList();
         for (Map.Entry<String, String> entry : map.entrySet()) {
             this.checkAndWriteString(KVPathUtil.getHaStatusPath() + SEPARATOR, entry.getKey(), entry.getValue());


### PR DESCRIPTION
Signed-off-by: dcy <dcy10000@gmail.com>

Reason:  
  BUG inner-1253: make sure XmlSchemaLoader read the newest data of HA when use reload
Type:  
  BUG
Influences：  
   reload
