### PR TITLE
inner-1253-bugfix: make sure XmlSchemaLoader read the newest data of  HA when use reload

### DIFF
--- a/src/main/java/com/actiontech/dble/config/loader/zkprocess/comm/ZookeeperProcessListen.java
+++ b/src/main/java/com/actiontech/dble/config/loader/zkprocess/comm/ZookeeperProcessListen.java
@@ -21,7 +21,7 @@ public class ZookeeperProcessListen {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperProcessListen.class);
 
-    private Set<NotifyService> initCache = new HashSet<>();
+    private Set<NotifyService> initCache = new LinkedHashSet<>();
     private Map<String, NotifyService> watchMap = new HashMap<>();
 
     public void addToInit(NotifyService service) {


### PR DESCRIPTION

Signed-off-by: dcy <dcy10000@gmail.com>

Reason:  
  BUG inner-1253-bugfix: make sure XmlSchemaLoader read the newest data of  HA when use reload
Type:  
  BUG
Influences：  
   fix xx
