### PR TITLE
'txInterrupted' is not updated when an implicit commit statement is executed in error

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/FieldListHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/FieldListHandler.java
@@ -3,7 +3,6 @@ package com.actiontech.dble.backend.mysql.nio.handler;
 import com.actiontech.dble.DbleServer;
 import com.actiontech.dble.backend.datasource.ShardingNode;
 import com.actiontech.dble.config.ErrorCode;
-import com.actiontech.dble.config.model.user.UserName;
 import com.actiontech.dble.net.connection.BackendConnection;
 import com.actiontech.dble.net.mysql.ErrorPacket;
 import com.actiontech.dble.net.mysql.FieldPacket;
@@ -157,13 +156,13 @@ public class FieldListHandler implements ResponseHandler {
 
     private void backConnectionErr(ErrorPacket errPkg, @Nullable MySQLResponseService responseService, boolean syncFinished) {
         ShardingService shardingService = session.getShardingService();
-        UserName errUser = shardingService.getUser();
-        String errHost = shardingService.getConnection().getHost();
-        int errPort = shardingService.getConnection().getLocalPort();
-        String errMsg = " errNo:" + errPkg.getErrNo() + " " + new String(errPkg.getMessage());
+        String errMsg = "errNo:" + errPkg.getErrNo() + " " + new String(errPkg.getMessage());
         if (responseService != null && !responseService.isFakeClosed()) {
-            LOGGER.info("execute sql err :" + errMsg + " con:" + responseService +
-                    " frontend host:" + errHost + "/" + errPort + "/" + errUser);
+            LOGGER.info("execute sql err:{}, con:{}, frontend host:{}/{}/{}", errMsg, responseService,
+                    shardingService.getConnection().getHost(),
+                    shardingService.getConnection().getLocalPort(),
+                    shardingService.getUser());
+
             if (responseService.getConnection().isClosed()) {
                 if (responseService.getAttachment() != null) {
                     RouteResultsetNode rNode = (RouteResultsetNode) responseService.getAttachment();

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeDdlPrepareHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeDdlPrepareHandler.java
@@ -277,8 +277,8 @@ public class MultiNodeDdlPrepareHandler extends MultiNodeHandler implements Exec
                     if (!session.isKilled()) {
                         handler.execute();
                     } else {
-                        DDLTraceManager.getInstance().endDDL(shardingService, "Query was interrupted");
                         session.handleSpecial(oriRrs, false, null);
+                        DDLTraceManager.getInstance().endDDL(shardingService, "Query was interrupted");
                         ErrorPacket errPacket = new ErrorPacket();
                         errPacket.setPacketId(session.getShardingService().nextPacketId());
                         errPacket.setErrNo(ErrorCode.ER_QUERY_INTERRUPTED);
@@ -286,9 +286,9 @@ public class MultiNodeDdlPrepareHandler extends MultiNodeHandler implements Exec
                         handleRollbackPacket(errPacket.toBytes(), "Query was interrupted");
                     }
                 } catch (Exception e) {
-                    DDLTraceManager.getInstance().endDDL(shardingService, "take Connection error:" + e.getMessage());
                     LOGGER.warn(String.valueOf(shardingService) + oriRrs, e);
                     session.handleSpecial(oriRrs, false, null);
+                    DDLTraceManager.getInstance().endDDL(shardingService, "take Connection error:" + e.getMessage());
                     shardingService.writeErrMessage(ErrorCode.ERR_HANDLE_DATA, e.toString());
                 }
             }
@@ -327,12 +327,10 @@ public class MultiNodeDdlPrepareHandler extends MultiNodeHandler implements Exec
     private void handleRollbackPacket(byte[] data, String reason) {
         ShardingService source = session.getShardingService();
         boolean inTransaction = !source.isAutocommit() || source.isTxStart();
+        LOGGER.warn(reason);
         if (!inTransaction) {
             // normal query
             session.closeAndClearResources(reason);
-        } else {
-            // Explicit distributed transaction
-            source.setTxInterrupt(reason);
         }
         source.write(data, WriteFlags.SESSION_END);
     }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeHandler.java
@@ -144,7 +144,7 @@ public abstract class MultiNodeHandler implements ResponseHandler {
         return false;
     }
 
-    void tryErrorFinished(boolean allEnd) {
+    protected void tryErrorFinished(boolean allEnd) {
         if (allEnd && !session.closed()) {
             // clear session resources,release all
             if (LOGGER.isDebugEnabled()) {
@@ -157,7 +157,7 @@ public abstract class MultiNodeHandler implements ResponseHandler {
         }
     }
 
-    private void clearSessionResources() {
+    protected void clearSessionResources() {
         if (session.getShardingService().isAutocommit()) {
             session.closeAndClearResources(error);
         } else {
@@ -175,7 +175,7 @@ public abstract class MultiNodeHandler implements ResponseHandler {
         RouteResultsetNode rNode = (RouteResultsetNode) ((MySQLResponseService) service).getAttachment();
         session.getTargetMap().remove(rNode);
         ((MySQLResponseService) service).setResponseHandler(null);
-        tryErrorFinished(decrementToZero((MySQLResponseService) service));
+        this.tryErrorFinished(decrementToZero((MySQLResponseService) service));
     }
 
     public void clearResources() {

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeQueryHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MultiNodeQueryHandler.java
@@ -173,7 +173,8 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
 
     @Override
     public void clearAfterFailExecute() {
-        if (!session.getShardingService().isAutocommit() || session.getShardingService().isTxStart()) {
+        if ((!session.getShardingService().isAutocommit() || session.getShardingService().isTxStart()) &&
+                !(this instanceof MultiNodeDDLExecuteHandler)) {
             session.getShardingService().setTxInterrupt("ROLLBACK");
         }
         waitAllConnConnectorError();
@@ -551,7 +552,9 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
         }
         if (service != null && !service.isFakeClosed()) {
             errConnection.add(service);
-            if (service.getConnection().isClosed() && (!session.getShardingService().isAutocommit() || session.getShardingService().isTxStart())) {
+            if (service.getConnection().isClosed() &&
+                    (!session.getShardingService().isAutocommit() || session.getShardingService().isTxStart()) &&
+                    !(this instanceof MultiNodeDDLExecuteHandler)) {
                 session.getShardingService().setTxInterrupt(error);
             }
         }
@@ -718,7 +721,8 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
             }
 
             // Explicit Distributed Transaction
-            if (inTransaction && (AutoTxOperation.ROLLBACK == txOperation)) {
+            if (inTransaction && (AutoTxOperation.ROLLBACK == txOperation) &&
+                    !(this instanceof MultiNodeDDLExecuteHandler)) {
                 service.setTxInterrupt("ROLLBACK");
             }
             session.setResponseTime(isSuccess);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MysqlDropViewHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MysqlDropViewHandler.java
@@ -28,7 +28,7 @@ public class MysqlDropViewHandler extends MultiNodeDDLExecuteHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(MysqlDropViewHandler.class);
     private ViewMeta vm; //if only for replace from a no sharding view to a sharding view
 
-    public MysqlDropViewHandler(NonBlockingSession session, RouteResultset rrs, int viewNodeNum, ViewMeta vm) {
+    public MysqlDropViewHandler(NonBlockingSession session, RouteResultset rrs, ViewMeta vm) {
         super(rrs, session);
         this.vm = vm;
     }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MysqlDropViewHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/MysqlDropViewHandler.java
@@ -5,200 +5,85 @@
 
 package com.actiontech.dble.backend.mysql.nio.handler;
 
-import com.actiontech.dble.DbleServer;
-import com.actiontech.dble.backend.datasource.ShardingNode;
 import com.actiontech.dble.cluster.values.DDLTraceInfo;
-import com.actiontech.dble.config.ErrorCode;
-import com.actiontech.dble.config.model.user.UserName;
-import com.actiontech.dble.log.transaction.TxnLogHelper;
 import com.actiontech.dble.meta.ViewMeta;
-import com.actiontech.dble.net.connection.BackendConnection;
-import com.actiontech.dble.net.mysql.*;
+import com.actiontech.dble.net.mysql.OkPacket;
 import com.actiontech.dble.net.service.AbstractService;
 import com.actiontech.dble.route.RouteResultset;
-import com.actiontech.dble.route.RouteResultsetNode;
 import com.actiontech.dble.server.NonBlockingSession;
 import com.actiontech.dble.services.mysqlsharding.MySQLResponseService;
 import com.actiontech.dble.services.mysqlsharding.ShardingService;
 import com.actiontech.dble.singleton.DDLTraceManager;
-import com.actiontech.dble.util.StringUtil;
+import com.actiontech.dble.singleton.TraceManager;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.sql.SQLNonTransientException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @Author collapsar
  */
-public class MysqlDropViewHandler implements ResponseHandler, ExecutableHandler {
+public class MysqlDropViewHandler extends MultiNodeDDLExecuteHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(MysqlDropViewHandler.class);
-    private NonBlockingSession session;
-    private RouteResultset rrs;
-    private volatile byte packetId;
-    private AtomicInteger viewNodeNum;
     private ViewMeta vm; //if only for replace from a no sharding view to a sharding view
 
     public MysqlDropViewHandler(NonBlockingSession session, RouteResultset rrs, int viewNodeNum, ViewMeta vm) {
-        this.session = session;
-        this.rrs = rrs;
-        this.packetId = (byte) session.getPacketId().get();
-        this.viewNodeNum = new AtomicInteger(viewNodeNum);
+        super(rrs, session);
         this.vm = vm;
-        TxnLogHelper.putTxnLog(session.getShardingService(), rrs);
     }
 
+    @Override
     public void execute() throws Exception {
-        DDLTraceManager.getInstance().updateDDLStatus(DDLTraceInfo.DDLStage.EXECUTE_START, session.getShardingService());
-        for (RouteResultsetNode node : rrs.getNodes()) {
-            BackendConnection conn = session.getTarget(node);
-            if (session.tryExistsCon(conn, node)) {
-                innerExecute(conn, node);
-            } else {
-                // create new connection
-                ShardingNode dn = DbleServer.getInstance().getConfig().getShardingNodes().get(node.getName());
-                dn.getConnection(dn.getDatabase(), session.getShardingService().isTxStart(), session.getShardingService().isAutocommit(), node, this, node);
-            }
-        }
-    }
-
-    private void innerExecute(BackendConnection conn, RouteResultsetNode node) {
-        DDLTraceManager.getInstance().updateConnectionStatus(session.getShardingService(), conn.getBackendService(), DDLTraceInfo.DDLConnectionStatus.CONN_EXECUTE_START);
-        conn.getBackendService().setResponseHandler(this);
-        conn.getBackendService().setSession(session);
-        conn.getBackendService().execute(node, session.getShardingService(), session.getShardingService().isAutocommit());
-    }
-
-    @Override
-    public void connectionAcquired(BackendConnection conn) {
-        final RouteResultsetNode node = (RouteResultsetNode) conn.getBackendService().getAttachment();
-        session.bindConnection(node, conn);
-        innerExecute(conn, node);
-    }
-
-    @Override
-    public void connectionError(Throwable e, Object attachment) {
-        DDLTraceManager.getInstance().updateRouteNodeStatus(session.getShardingService(), (RouteResultsetNode) attachment, DDLTraceInfo.DDLConnectionStatus.EXECUTE_CONN_ERROR);
-        DDLTraceManager.getInstance().endDDL(session.getShardingService(), e.getMessage());
-        RouteResultsetNode rrn = (RouteResultsetNode) attachment;
-        ErrorPacket errPacket = new ErrorPacket();
-        errPacket.setPacketId(++packetId);
-        errPacket.setErrNo(ErrorCode.ER_DB_INSTANCE_ABORTING_CONNECTION);
-        String errMsg = "can't connect to shardingNode[" + rrn.getName() + "], due to " + e.getMessage();
-        errPacket.setMessage(StringUtil.encode(errMsg, session.getShardingService().getCharset().getResults()));
-        LOGGER.warn(errMsg);
-        backConnectionErr(errPacket, null, false);
-    }
-
-    @Override
-    public void errorResponse(byte[] data, @NotNull AbstractService service) {
-        DDLTraceManager.getInstance().updateConnectionStatus(session.getShardingService(),
-                (MySQLResponseService) service, DDLTraceInfo.DDLConnectionStatus.CONN_EXECUTE_ERROR);
-        DDLTraceManager.getInstance().endDDL(session.getShardingService(), "ddl end with execution failure");
-        ErrorPacket errPkg = new ErrorPacket();
-        errPkg.read(data);
-        errPkg.setPacketId(++packetId);
-        backConnectionErr(errPkg, (MySQLResponseService) service, ((MySQLResponseService) service).syncAndExecute());
+        super.execute();
     }
 
     @Override
     public void okResponse(byte[] data, @NotNull AbstractService service) {
+        TraceManager.TraceObject traceObject = TraceManager.serviceTrace(service, "get-ok-response");
+        TraceManager.finishSpan(service, traceObject);
         boolean executeResponse = ((MySQLResponseService) service).syncAndExecute();
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("received ok response ,executeResponse:" + executeResponse + " from " + service);
         }
-        if (!executeResponse) {
-            return;
-        }
-        DDLTraceManager.getInstance().updateConnectionStatus(session.getShardingService(), (MySQLResponseService) service, DDLTraceInfo.DDLConnectionStatus.CONN_EXECUTE_SUCCESS);
-        if (viewNodeNum.decrementAndGet() == 0) {
-            if (vm != null) { // replace a new sharding view
-                try {
-                    vm.addMeta(true);
-                } catch (SQLNonTransientException e) {
-                    DDLTraceManager.getInstance().endDDL(session.getShardingService(), "ddl end with meta failure");
-                    ErrorPacket errPkg = new ErrorPacket();
-                    errPkg.setPacketId(++packetId);
-                    errPkg.setMessage(StringUtil.encode(e.getMessage(), session.getShardingService().getCharset().getResults()));
-                    backConnectionErr(errPkg, ((MySQLResponseService) service), ((MySQLResponseService) service).syncAndExecute());
+        if (executeResponse) {
+            DDLTraceManager.getInstance().updateConnectionStatus(session.getShardingService(),
+                    (MySQLResponseService) service, DDLTraceInfo.DDLConnectionStatus.CONN_EXECUTE_SUCCESS);
+            session.setBackendResponseEndTime((MySQLResponseService) service);
+            lock.lock();
+            try {
+                ShardingService source = session.getShardingService();
+                if (!decrementToZero((MySQLResponseService) service))
                     return;
+                if (isFail()) {
+                    DDLTraceManager.getInstance().endDDL(source, "ddl end with execution failure");
+                    session.resetMultiStatementStatus();
+                    handleEndPacket(err, false);
+                } else {
+                    if (vm != null) {
+                        try {
+                            vm.addMeta(true);
+                        } catch (SQLNonTransientException e) {
+                            DDLTraceManager.getInstance().endDDL(session.getShardingService(), "ddl end with meta failure");
+                            session.resetMultiStatementStatus();
+                            executeMetaDataFailed(e.getMessage());
+                            return;
+                        }
+                    }
+                    session.setRowCount(0);
+                    DDLTraceManager.getInstance().endDDL(source, null);
+                    OkPacket ok = new OkPacket();
+                    ok.read(data);
+                    ok.setMessage(null);
+                    ok.setAffectedRows(0);
+                    ok.setServerStatus(source.isAutocommit() ? 2 : 1);
+                    doSqlStat();
+                    handleEndPacket(ok, true);
                 }
-            }
-            DDLTraceManager.getInstance().endDDL(session.getShardingService(), null);
-            // return ok
-            OkPacket ok = new OkPacket();
-            ok.read(data);
-            ok.setPacketId(++packetId); // OK_PACKET
-            ok.setServerStatus(session.getShardingService().isAutocommit() ? 2 : 1);
-            session.setBackendResponseEndTime(((MySQLResponseService) service));
-            session.releaseConnectionIfSafe(((MySQLResponseService) service), false);
-            handleEndPacket(ok, true);
-        }
-    }
-
-    private void backConnectionErr(ErrorPacket errPkg, @Nullable MySQLResponseService service, boolean syncFinished) {
-        ShardingService shardingService = session.getShardingService();
-        UserName errUser = shardingService.getUser();
-        String errHost = shardingService.getConnection().getHost();
-        int errPort = shardingService.getConnection().getLocalPort();
-        String errMsg = " errNo:" + errPkg.getErrNo() + " " + new String(errPkg.getMessage());
-        if (service != null && !service.isFakeClosed()) {
-            LOGGER.info("execute sql err :" + errMsg + " con:" + service +
-                    " frontend host:" + errHost + "/" + errPort + "/" + errUser);
-            if (syncFinished) {
-                session.releaseConnectionIfSafe(service, false);
-            } else {
-                service.getConnection().businessClose("unfinished sync");
-                session.getTargetMap().remove(service.getAttachment());
+            } finally {
+                lock.unlock();
             }
         }
-
-        if (viewNodeNum.decrementAndGet() == 0) {
-            shardingService.setTxInterrupt(errMsg);
-            handleEndPacket(errPkg, false);
-        }
     }
 
-    @Override
-    public void fieldEofResponse(byte[] header, List<byte[]> fields, List<FieldPacket> fieldPackets, byte[] eof, boolean isLeft, @NotNull AbstractService service) {
-        //not happen
-    }
-
-    @Override
-    public boolean rowResponse(byte[] rowNull, RowDataPacket rowPacket, boolean isLeft, @NotNull AbstractService service) {
-        //not happen
-        return false;
-    }
-
-    @Override
-    public void rowEofResponse(byte[] eof, boolean isLeft, @NotNull AbstractService service) {
-        //not happen
-    }
-
-    @Override
-    public void connectionClose(@NotNull AbstractService service, String reason) {
-        DDLTraceManager.getInstance().updateConnectionStatus(session.getShardingService(),
-                (MySQLResponseService) service, DDLTraceInfo.DDLConnectionStatus.EXECUTE_CONN_CLOSE);
-        DDLTraceManager.getInstance().endDDL(session.getShardingService(), reason);
-        //not happen
-    }
-
-    @Override
-    public void clearAfterFailExecute() {
-
-    }
-
-    @Override
-    public void writeRemainBuffer() {
-
-    }
-
-    private void handleEndPacket(MySQLPacket packet, boolean isSuccess) {
-        session.setResponseTime(isSuccess);
-        session.clearResources(false);
-        packet.write(session.getSource());
-    }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeDDLHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeDDLHandler.java
@@ -76,6 +76,7 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
                 ShardingService sessionShardingService = session.getShardingService();
                 OkPacket ok = new OkPacket();
                 ok.read(data);
+                ok.setPacketId(sessionShardingService.nextPacketId()); // OK_PACKET
                 ok.setMessage(null);
                 ok.setServerStatus(sessionShardingService.isAutocommit() ? 2 : 1);
                 sessionShardingService.setLastInsertId(ok.getInsertId());
@@ -91,6 +92,7 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
 
     public void executeMetaDataFailed(MySQLResponseService service, String errMsg) {
         ErrorPacket errPacket = new ErrorPacket();
+        errPacket.setPacketId(session.getShardingService().nextPacketId());
         errPacket.setErrNo(ErrorCode.ER_META_DATA);
         if (errMsg == null) {
             errMsg = "Create TABLE OK, but generate metedata failed. The reason may be that the current druid parser can not recognize part of the sql" +
@@ -141,7 +143,6 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
     protected void handleEndPacket(MySQLPacket packet, boolean isSuccess) {
         session.clearResources(false);
         session.setResponseTime(isSuccess);
-        packet.setPacketId(session.getShardingService().nextPacketId());
         packet.write(session.getSource());
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeDDLHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeDDLHandler.java
@@ -2,7 +2,6 @@ package com.actiontech.dble.backend.mysql.nio.handler;
 
 import com.actiontech.dble.cluster.values.DDLTraceInfo;
 import com.actiontech.dble.config.ErrorCode;
-import com.actiontech.dble.config.model.user.UserName;
 import com.actiontech.dble.net.mysql.ErrorPacket;
 import com.actiontech.dble.net.mysql.MySQLPacket;
 import com.actiontech.dble.net.mysql.OkPacket;
@@ -45,7 +44,6 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
         super.connectionError(e, attachment);
     }
 
-
     @Override
     public void errorResponse(byte[] data, @NotNull AbstractService service) {
         DDLTraceManager.getInstance().updateConnectionStatus(session.getShardingService(),
@@ -62,7 +60,6 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
         super.connectionClose(service, reason);
     }
 
-
     @Override
     public void okResponse(byte[] data, @NotNull AbstractService service) {
         boolean executeResponse = ((MySQLResponseService) service).syncAndExecute();
@@ -72,14 +69,13 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
             boolean metaInitial = session.handleSpecial(rrs, true, null);
             if (!metaInitial) {
                 DDLTraceManager.getInstance().endDDL(session.getShardingService(), "ddl end with meta failure");
-                executeMetaDataFailed((MySQLResponseService) service);
+                executeMetaDataFailed((MySQLResponseService) service, null);
             } else {
                 DDLTraceManager.getInstance().endDDL(session.getShardingService(), null);
                 session.setRowCount(0);
                 ShardingService sessionShardingService = session.getShardingService();
                 OkPacket ok = new OkPacket();
                 ok.read(data);
-                ok.setPacketId(sessionShardingService.nextPacketId()); // OK_PACKET
                 ok.setMessage(null);
                 ok.setServerStatus(sessionShardingService.isAutocommit() ? 2 : 1);
                 sessionShardingService.setLastInsertId(ok.getInsertId());
@@ -93,14 +89,14 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
         }
     }
 
-    private void executeMetaDataFailed(MySQLResponseService service) {
+    public void executeMetaDataFailed(MySQLResponseService service, String errMsg) {
         ErrorPacket errPacket = new ErrorPacket();
-        errPacket.setPacketId(session.getShardingService().nextPacketId());
         errPacket.setErrNo(ErrorCode.ER_META_DATA);
-        String errMsg = "Create TABLE OK, but generate metedata failed. The reason may be that the current druid parser can not recognize part of the sql" +
-                " or the user for backend mysql does not have permission to execute the heartbeat sql.";
+        if (errMsg == null) {
+            errMsg = "Create TABLE OK, but generate metedata failed. The reason may be that the current druid parser can not recognize part of the sql" +
+                    " or the user for backend mysql does not have permission to execute the heartbeat sql.";
+        }
         errPacket.setMessage(StringUtil.encode(errMsg, session.getShardingService().getCharset().getResults()));
-
         session.setBackendResponseEndTime(service);
         session.releaseConnectionIfSafe(service, false);
         session.multiStatementPacket(errPacket);
@@ -130,23 +126,22 @@ public class SingleNodeDDLHandler extends SingleNodeHandler {
         }
 
         ShardingService shardingService = session.getShardingService();
-        String errMsg = " errNo:" + errPkg.getErrNo() + " " + new String(errPkg.getMessage());
-        UserName errUser = shardingService.getUser();
-        String errHost = shardingService.getConnection().getHost();
-        LOGGER.info("execute sql err :" + errMsg + " con:" + service +
-                " frontend host:" + errHost + "/" + errUser);
+        String errMsg = "errNo:" + errPkg.getErrNo() + " " + new String(errPkg.getMessage());
+        LOGGER.info("execute sql err:{}, con:{}, frontend host:{}/{}/{}", errMsg, service,
+                shardingService.getConnection().getHost(),
+                shardingService.getConnection().getLocalPort(),
+                shardingService.getUser());
 
-        shardingService.setTxInterrupt(errMsg);
         if (writeToClient.compareAndSet(false, true)) {
             session.handleSpecial(rrs, false, null);
             handleEndPacket(errPkg, false);
         }
     }
 
-
-    private void handleEndPacket(MySQLPacket packet, boolean isSuccess) {
-        session.setResponseTime(isSuccess);
+    protected void handleEndPacket(MySQLPacket packet, boolean isSuccess) {
         session.clearResources(false);
+        session.setResponseTime(isSuccess);
+        packet.setPacketId(session.getShardingService().nextPacketId());
         packet.write(session.getSource());
     }
 }

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/SingleNodeHandler.java
@@ -156,6 +156,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
     public void connectionError(Throwable e, Object attachment) {
         RouteResultsetNode rrn = (RouteResultsetNode) attachment;
         ErrorPacket errPacket = new ErrorPacket();
+        errPacket.setPacketId(session.getShardingService().nextPacketId());
         errPacket.setErrNo(ErrorCode.ER_DB_INSTANCE_ABORTING_CONNECTION);
         String errMsg = "can't connect to shardingNode[" + rrn.getName() + "], due to " + e.getMessage();
         errPacket.setMessage(StringUtil.encode(errMsg, session.getShardingService().getCharset().getResults()));
@@ -168,6 +169,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
         session.resetMultiStatementStatus();
         ErrorPacket err = new ErrorPacket();
         err.read(data);
+        err.setPacketId(session.getShardingService().nextPacketId());
         backConnectionErr(err, (MySQLResponseService) service, ((MySQLResponseService) service).syncAndExecute());
     }
 
@@ -447,6 +449,7 @@ public class SingleNodeHandler implements ResponseHandler, LoadDataResponseHandl
                 ((MySQLResponseService) service).getConnection().getThreadId() + "]} was closed ,reason is [" + reason + "]";
         session.getSource().setSkipCheck(false);
         ErrorPacket err = new ErrorPacket();
+        err.setPacketId((byte) session.getShardingService().nextPacketId());
         err.setErrNo(ErrorCode.ER_ERROR_ON_CLOSE);
         err.setMessage(StringUtil.encode(reason, session.getShardingService().getCharset().getResults()));
         this.backConnectionErr(err, (MySQLResponseService) service, true);

--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/UnLockTablesHandler.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/handler/UnLockTablesHandler.java
@@ -110,8 +110,8 @@ public class UnLockTablesHandler extends MultiNodeHandler implements ResponseHan
             boolean isEndPack = decrementToZero(((MySQLResponseService) service));
             session.releaseConnection(((MySQLResponseService) service).getConnection());
             if (isEndPack) {
-                if (this.isFail() || session.closed()) {
-                    tryErrorFinished(true);
+                if (this.isFail()) {
+                    this.tryErrorFinished(true);
                     return;
                 }
                 OkPacket ok = new OkPacket();

--- a/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidAlterViewParser.java
+++ b/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidAlterViewParser.java
@@ -54,7 +54,7 @@ public class DruidAlterViewParser extends DruidImplicitCommitParser {
             if (isCreate) {
                 return new MysqlCreateViewHandler(service.getSession2(), rrs, vm);
             } else {
-                return new MysqlDropViewHandler(service.getSession2(), rrs, 1, vm);
+                return new MysqlDropViewHandler(service.getSession2(), rrs, vm);
             }
         }
         return null;

--- a/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidCreateOrReplaceViewParser.java
+++ b/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidCreateOrReplaceViewParser.java
@@ -69,7 +69,7 @@ public class DruidCreateOrReplaceViewParser extends DruidImplicitCommitParser {
             if (isCreate) {
                 return new MysqlCreateViewHandler(service.getSession2(), rrs, vm);
             } else {
-                return new MysqlDropViewHandler(service.getSession2(), rrs, 1, vm);
+                return new MysqlDropViewHandler(service.getSession2(), rrs, vm);
             }
         }
         return null;

--- a/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidDropViewParser.java
+++ b/src/main/java/com/actiontech/dble/route/parser/druid/impl/ddl/DruidDropViewParser.java
@@ -25,7 +25,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class DruidDropViewParser extends DruidImplicitCommitParser {
-    int viewNodeNum = 0;
 
     @Override
     public SchemaConfig doVisitorParse(SchemaConfig schema, RouteResultset rrs, SQLStatement stmt, ServerSchemaStatVisitor visitor, ShardingService service, boolean isExplain) throws SQLException {
@@ -70,7 +69,6 @@ public class DruidDropViewParser extends DruidImplicitCommitParser {
                 nodes.add(new RouteResultsetNode(n.getKey(), rrs.getSqlType(), dropStmt.toString()));
             }
             rrs.setNodes(nodes.toArray(new RouteResultsetNode[nodes.size()]));
-            viewNodeNum = nodes.size();
             rrs.setFinishedRoute(true);
         } else {
             rrs.setFinishedExecute(true);
@@ -80,7 +78,7 @@ public class DruidDropViewParser extends DruidImplicitCommitParser {
 
     @Override
     public ExecutableHandler visitorParseEnd(RouteResultset rrs, ShardingService service) {
-        return new MysqlDropViewHandler(service.getSession2(), rrs, viewNodeNum, null);
+        return new MysqlDropViewHandler(service.getSession2(), rrs, null);
     }
 
     private void checkView(String defaultSchema, SQLDropViewStatement dropViewStatement) throws SQLException {

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -1003,10 +1003,16 @@ public class NonBlockingSession extends Session {
     }
 
     public boolean handleSpecial(RouteResultset rrs, boolean isSuccess, String errInfo) {
+        if (rrs.getDdlHandler() == null ||
+                // rrs.getDdlHandler() instanceof LockTablesHandler ||
+                rrs.getDdlHandler() instanceof MysqlCreateViewHandler ||
+                rrs.getDdlHandler() instanceof MysqlDropViewHandler) {
+            return true;
+        }
         if (rrs.getSchema() != null) {
             String sql = rrs.getSrcStatement();
             if (rrs.isOnline()) {
-                LOGGER.info("online ddl skip updating meta and cluster notify, Schema[" + rrs.getSchema() + "],SQL[" + sql + "]" + (errInfo != null ? "errorInfo:" + errInfo : ""));
+                LOGGER.info("Online ddl skip updating meta and cluster notify, Schema[" + rrs.getSchema() + "],SQL[" + sql + "]" + (errInfo != null ? "errorInfo:" + errInfo : ""));
                 return true;
             }
             if (!isSuccess) {


### PR DESCRIPTION
Reason:  
  BUG inner 1261
Type:  
  BUG
Influences：  
   1、 'txInterrupted' is not updated when an implicit commit statement is executed in error
         2、Adjust the class(LockTablesHandler/MysqlCreateViewHandler/MysqlDropViewHandler ..)
