### PR TITLE
inner-1280: fix miss id in lower_case_table_name clone

### DIFF
--- a/src/main/java/com/actiontech/dble/config/model/sharding/table/ChildTableConfig.java
+++ b/src/main/java/com/actiontech/dble/config/model/sharding/table/ChildTableConfig.java
@@ -33,8 +33,10 @@ public class ChildTableConfig extends BaseTableConfig {
 
     @Override
     public BaseTableConfig lowerCaseCopy(BaseTableConfig parent) {
-        return new ChildTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes,
+        ChildTableConfig config = new ChildTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes,
                 parent, this.joinColumn, this.parentColumn, this.incrementColumn);
+        config.setId(this.getId());
+        return config;
     }
 
 

--- a/src/main/java/com/actiontech/dble/config/model/sharding/table/GlobalTableConfig.java
+++ b/src/main/java/com/actiontech/dble/config/model/sharding/table/GlobalTableConfig.java
@@ -36,7 +36,9 @@ public class GlobalTableConfig extends BaseTableConfig {
 
     @Override
     public BaseTableConfig lowerCaseCopy(BaseTableConfig parent) {
-        return new GlobalTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes, this.cron, this.checkClass, this.globalCheck);
+        GlobalTableConfig config = new GlobalTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes, this.cron, this.checkClass, this.globalCheck);
+        config.setId(this.getId());
+        return config;
     }
 
 

--- a/src/main/java/com/actiontech/dble/config/model/sharding/table/ShardingTableConfig.java
+++ b/src/main/java/com/actiontech/dble/config/model/sharding/table/ShardingTableConfig.java
@@ -44,8 +44,10 @@ public class ShardingTableConfig extends BaseTableConfig {
 
     @Override
     public BaseTableConfig lowerCaseCopy(BaseTableConfig parent) {
-        return new ShardingTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes,
+        ShardingTableConfig config = new ShardingTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes,
                 this.incrementColumn, this.function, this.shardingColumn, this.sqlRequiredSharding);
+        config.setId(this.getId());
+        return config;
     }
 
 

--- a/src/main/java/com/actiontech/dble/config/model/sharding/table/SingleTableConfig.java
+++ b/src/main/java/com/actiontech/dble/config/model/sharding/table/SingleTableConfig.java
@@ -15,6 +15,8 @@ public final class SingleTableConfig extends BaseTableConfig {
 
     @Override
     public BaseTableConfig lowerCaseCopy(BaseTableConfig parent) {
-        return new SingleTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes);
+        SingleTableConfig config = new SingleTableConfig(this.name.toLowerCase(), this.maxLimit, this.shardingNodes);
+        config.setId(getId());
+        return config;
     }
 }


### PR DESCRIPTION
Reason:  
  BUG inner-1280: fix miss id in lower_case_table_name clone
Type:  
  BUG
Influences：  
  id of table config