### PR TITLE
Three (ER) table query results are incorrect

### DIFF
--- a/src/main/java/com/actiontech/dble/plan/optimizer/ERJoinChooser.java
+++ b/src/main/java/com/actiontech/dble/plan/optimizer/ERJoinChooser.java
@@ -206,7 +206,7 @@ public class ERJoinChooser {
                 continue;
             for (int j = i + 1; j < selList.size(); j++) {
                 JoinColumnInfo jkj = selList.get(j);
-                if (isErRelation(jki.cm, jkj.cm)) {
+                if (this.makedERJnList.isEmpty() && isErRelation(jki.cm, jkj.cm)) {
                     erKeys.add(jkj);
                 }
             }


### PR DESCRIPTION
Reason:  
  BUG //TODO
Type:  
  BUG
Influences：  
   fix :Three (ER) table query results are incorrect
