### PR TITLE
inner#1152 - reset fullyConfigured flag when enabling dbGroup

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
@@ -333,6 +333,7 @@ public class PhysicalDbGroup {
             for (String dsName : nameList) {
                 allSourceMap.get(dsName).enable();
             }
+            DbleServer.getInstance().getConfig().fulllyConfigured();
             return this.getClusterHaJson();
         } finally {
             lock.readLock().unlock();

--- a/src/main/java/com/actiontech/dble/config/ServerConfig.java
+++ b/src/main/java/com/actiontech/dble/config/ServerConfig.java
@@ -164,6 +164,14 @@ public class ServerConfig {
         return fullyConfigured;
     }
 
+    public void fulllyConfigured() {
+        if (fullyConfigured) {
+            return;
+        }
+        waitIfChanging();
+        fullyConfigured = true;
+    }
+
     public Map<UserName, UserConfig> getUsers() {
         waitIfChanging();
         return users;
@@ -519,7 +527,7 @@ public class ServerConfig {
 
     }
 
-    public void loadSequence() {
+    private void loadSequence() {
         SequenceManager.load(DbleServer.getInstance().getSystemVariables().isLowerCaseTableNames());
     }
 


### PR DESCRIPTION
Reason:  
  BUG #inner1152.
Type:  
  BUG
Influences：  
  reset fullyConfigured flag when enabling dbGroup
