### PR TITLE
fix[inner-1455]: 'ConcurrentModificationException' occurred while loading metadata

### DIFF
--- a/src/main/java/com/actiontech/dble/meta/table/GetTableMetaHandler.java
+++ b/src/main/java/com/actiontech/dble/meta/table/GetTableMetaHandler.java
@@ -18,6 +18,7 @@ import com.actiontech.dble.sqlengine.MultiTablesMetaJob;
 import com.actiontech.dble.sqlengine.SQLQueryResult;
 import com.actiontech.dble.sqlengine.SQLQueryResultListener;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -74,7 +75,7 @@ public abstract class GetTableMetaHandler {
 
         TableStructureListener(String shardingNode, Set<String> expectedTables, PhysicalDbInstance ds) {
             this.shardingNode = shardingNode;
-            this.expectedTables = expectedTables;
+            this.expectedTables = new HashSet<>(expectedTables);
             this.ds = ds;
         }
 


### PR DESCRIPTION

Reason:  
  BUG inner 1455
Type:  
  BUG
Influences：  
   fix：'ConcurrentModificationException' occurred while loading metadata
