### PR TITLE
inner-1544: fix LVS/SLB heartbeat cause memory leak

### DIFF
--- a/src/main/java/com/actiontech/dble/net/connection/AbstractConnection.java
+++ b/src/main/java/com/actiontech/dble/net/connection/AbstractConnection.java
@@ -400,6 +400,14 @@ public abstract class AbstractConnection implements Connection {
         return readBuffer;
     }
 
+
+    public synchronized void recycleReadBuffer() {
+        if (readBuffer != null) {
+            this.recycle(readBuffer);
+            this.readBuffer = null;
+        }
+    }
+
     public void onConnectFailed(Throwable e) {
     }
 

--- a/src/main/java/com/actiontech/dble/net/impl/aio/AIOSocketWR.java
+++ b/src/main/java/com/actiontech/dble/net/impl/aio/AIOSocketWR.java
@@ -39,12 +39,22 @@ public class AIOSocketWR extends SocketWR {
     }
 
     @Override
-    public void asyncRead() {
-        ByteBuffer theBuffer = con.findReadBuffer();
-        if (theBuffer.hasRemaining()) {
-            channel.read(theBuffer, this, AIO_READ_HANDLER);
-        } else {
-            throw new IllegalArgumentException("full buffer to read ");
+    public void asyncRead() throws IOException {
+        if (con.isClosed()) {
+            throw new IOException("read from closed channel cause error");
+        }
+        try {
+            ByteBuffer theBuffer = con.findReadBuffer();
+            if (theBuffer.hasRemaining()) {
+                channel.read(theBuffer, this, AIO_READ_HANDLER);
+            } else {
+                throw new IllegalArgumentException("full buffer to read ");
+            }
+        } finally {
+            //prevent  asyncClose and read operation happened Concurrently.
+            if (con.isClosed() && con.getReadBuffer() != null) {
+                con.recycleReadBuffer();
+            }
         }
 
     }

--- a/src/main/java/com/actiontech/dble/net/impl/nio/NIOSocketWR.java
+++ b/src/main/java/com/actiontech/dble/net/impl/nio/NIOSocketWR.java
@@ -276,9 +276,19 @@ public class NIOSocketWR extends SocketWR {
 
     @Override
     public void asyncRead() throws IOException {
-        ByteBuffer theBuffer = con.findReadBuffer();
-        int got = channel.read(theBuffer);
-        con.onReadData(got);
+        if (con.isClosed()) {
+            throw new IOException("read from closed channel cause error");
+        }
+        try {
+            ByteBuffer theBuffer = con.findReadBuffer();
+            int got = channel.read(theBuffer);
+            con.onReadData(got);
+        } finally {
+            //prevent  asyncClose and read operation happened Concurrently.
+            if (con.isClosed() && con.getReadBuffer() != null) {
+                con.recycleReadBuffer();
+            }
+        }
     }
 
 


### PR DESCRIPTION
Signed-off-by: dcy <dcy10000@gmail.com>

Reason:  
  BUG: inner-1544: fix LVS/SLB heartbeat cause memory leak
Type:  
  BUG
Influences：  
   connection creation
