### PR TITLE
fix: processing of empty values when parsing csv

### DIFF
--- a/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/com/actiontech/dble/server/handler/ServerLoadDataInfileHandler.java
@@ -747,6 +747,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
             settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
             settings.setSkipEmptyLines(false);
             settings.trimValues(false);
+            settings.setEmptyValue("");
 
             CsvParser parser = new CsvParser(settings);
             try {
@@ -812,6 +813,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler 
         settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
 
         settings.trimValues(false);
+        settings.setEmptyValue("");
 
         CsvParser parser = new CsvParser(settings);
         InputStreamReader reader = null;


### PR DESCRIPTION
Reason:  
  BUG inner-1587
Type:  
  BUG
Influences：  
fix: processing of space values when parsing csv
