### PR TITLE
[inner-1615] During ddl execution, the creation and release of a table lock must be the same session on the business side

### DIFF
--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -688,10 +688,9 @@ public class NonBlockingSession extends Session {
             //lock self meta
             DDLProxyMetaManager.Originator.addTableMetaLock(shardingService, schema, table, rrs.getStatement());
         } catch (NeedDelayedException e) {
-            DDLProxyMetaManager.Originator.removeTableMetaLock(shardingService, schema, table);
+            // not happen
             throw e;
         } catch (Exception e) {
-            DDLProxyMetaManager.Originator.removeTableMetaLock(shardingService, schema, table);
             throw new SQLNonTransientException(e.getMessage() + ", sql: " + rrs.getStatement() + ".");
         }
     }


### PR DESCRIPTION

Reason:  
  BUG inner 1615
Type:  
  BUG/Improve  
Influences：  
   fix xx
