### PR TITLE
[inner-1615,950] During ddl execution, the creation and release of a table lock must be the same session on the business side (cherry pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -659,12 +659,11 @@ public class NonBlockingSession extends Session {
         String schema = rrs.getSchema();
         String table = rrs.getTable();
         try {
+            ProxyMeta.getInstance().getTmManager().notifyClusterDDL(schema, table, rrs.getStatement());
             //lock self meta
             ProxyMeta.getInstance().getTmManager().addMetaLock(schema, table, rrs.getSrcStatement());
-            ProxyMeta.getInstance().getTmManager().notifyClusterDDL(schema, table, rrs.getStatement());
         } catch (Exception e) {
-            ProxyMeta.getInstance().getTmManager().removeMetaLock(schema, table);
-            throw new SQLNonTransientException(e.toString() + ",sql:" + rrs.getStatement());
+            throw new SQLNonTransientException(e.getMessage() + ",sql:" + rrs.getStatement());
         }
     }
 


### PR DESCRIPTION

Reason:  
  BUG inner 1615,950; similar pr #3135 #2698 
Type:  
  BUG
Influences：  
   fix xx
