### PR TITLE
[inner-1615] During ddl execution, the creation and release of a table lock must be the same session on the business side (cherry pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -697,7 +697,6 @@ public class NonBlockingSession extends Session {
             //lock self meta
             ProxyMeta.getInstance().getTmManager().addMetaLock(schema, table, rrs.getSrcStatement());
         } catch (Exception e) {
-            ProxyMeta.getInstance().getTmManager().removeMetaLock(schema, table);
             throw new SQLNonTransientException(e.getMessage() + ", sql: " + rrs.getStatement() + ".");
         }
     }


### PR DESCRIPTION
Reason:  
  BUG 1615
Type:  
  BUG
Influences：  
   fix xx
