### PR TITLE
inner 1706 - remove schema incorrectly

### DIFF
--- a/src/main/java/com/actiontech/dble/route/util/RouterUtil.java
+++ b/src/main/java/com/actiontech/dble/route/util/RouterUtil.java
@@ -153,7 +153,7 @@ public final class RouterUtil {
     private static boolean checkPrefix(String content, int index) {
         if (index > 0) {
             char prefix = content.charAt(index - 1);
-            return prefix == ' ' || prefix == ',' || prefix == '(' || prefix == '=';
+            return !Character.isLetterOrDigit(prefix) && prefix != '_' && prefix != '-' && prefix != '$' && prefix != '.';
         }
         return false;
     }


### PR DESCRIPTION
Reason:  
  BUG #inner 1706.
Type:  
  BUG
Influences：  
  remove schema incorrectly,eg: table name contains schema name
