### PR TITLE
fix: newly added instance needs to create a connection pool immediately(cherry-pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -130,7 +130,7 @@ public final class DbleServer {
         LOGGER.info("=========================================Config file read finish==================================");
 
         LOGGER.info("=========================================Init Outer Ha Config==================================");
-        HaConfigManager.getInstance().init();
+        HaConfigManager.getInstance().init(false);
 
         if (SystemConfig.getInstance().getEnableAlert() == 1) {
             AlertUtil.switchAlert(true);

--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
@@ -360,9 +360,22 @@ public class PhysicalDbGroup {
             }
 
             if (ds.isAlive() && (!checkSlaveSynStatus() || ds.canSelectAsReadNode())) {
+                if (ds.getLogCount() != 0) {
+                    ds.setLogCount(0);
+                }
                 okSources.add(ds);
             } else {
-                LOGGER.warn("can't select dbInstance[{}] as read node, please check delay with primary", ds);
+                if (ds.isAlive()) {
+                    if (ds.getLogCount() != 0) {
+                        ds.setLogCount(0);
+                    }
+                    LOGGER.warn("can't select dbInstance[{}] as read node, please check delay with primary", ds);
+                } else {
+                    if (ds.getLogCount() < 10) {
+                        ds.setLogCount(ds.getLogCount() + 1);
+                        LOGGER.warn("can't select dbInstance[{}] as read node, please check the disabled and heartbeat status", ds);
+                    }
+                }
             }
         }
         if (okSources.size() == 0 && rwSplitMode == RW_SPLIT_ALL_SLAVES_MAY_MASTER && includeWrite) {

--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
@@ -56,6 +56,7 @@ public abstract class PhysicalDbInstance implements ReadTimeStatusInstance {
     private ConnectionPool connectionPool;
     protected MySQLHeartbeat heartbeat;
     private volatile boolean needSkipEvit = false;
+    private volatile int logCount;
 
     public PhysicalDbInstance(DbInstanceConfig config, DbGroupConfig dbGroupConfig, boolean isReadNode) {
         this.config = config;
@@ -324,6 +325,14 @@ public abstract class PhysicalDbInstance implements ReadTimeStatusInstance {
         this.isolationSynced = isolationSynced;
     }
 
+    public int getLogCount() {
+        return logCount;
+    }
+
+    public void setLogCount(int logCount) {
+        this.logCount = logCount;
+    }
+
     public String getDsVersion() {
         return dsVersion;
     }
@@ -399,6 +408,33 @@ public abstract class PhysicalDbInstance implements ReadTimeStatusInstance {
             connectionPool.stop(reason, closeFront);
         }
         isInitial.set(false);
+    }
+
+    public void updatePoolCapacity() {
+        //minCon/maxCon/numOfShardingNodes
+        if ((dbGroupConfig.getRwSplitMode() != RW_SPLIT_OFF || dbGroup.getWriteDbInstance() == this) && !dbGroup.isUseless()) {
+            checkPoolSize();
+            connectionPool.evictImmediately();
+            connectionPool.fillPool();
+        }
+    }
+
+    protected void checkPoolSize() {
+        int size = config.getMinCon();
+        String[] physicalSchemas = dbGroup.getSchemas();
+        int initSize = physicalSchemas.length;
+        if (size < initSize) {
+            LOGGER.warn("For db instance[{}], minIdle is less than (the count of shardingNodes), so dble will create at least 1 conn for every schema, " +
+                    "minCon size before:{}, now:{}", this.dbGroup.getGroupName() + "." + name, size, initSize);
+            config.setMinCon(initSize);
+        }
+
+        initSize = Math.max(initSize, config.getMinCon());
+        size = config.getMaxCon();
+        if (size < initSize) {
+            LOGGER.warn("For db instance[{}], maxTotal[{}] is less than the minCon or the count of shardingNodes,change the maxCon into {}", this.dbGroup.getGroupName() + "." + name, size, initSize);
+            config.setMaxCon(initSize);
+        }
     }
 
     public void closeAllConnection(String reason) {

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
@@ -107,7 +107,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
 
     private void setStatusForNormalHeartbeat(PhysicalDbInstance source) {
         if (checkRecoverFail(source)) return;
-        heartbeat.setResult(MySQLHeartbeat.OK_STATUS);
+        heartbeat.setResult(MySQLHeartbeatStatus.OK);
     }
 
     /**
@@ -118,7 +118,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
             LOGGER.warn("heartbeat[{}] had been stop", source.getConfig().getUrl());
             return true;
         }
-        if (heartbeat.getStatus() == MySQLHeartbeat.OK_STATUS) { // ok->ok
+        if (heartbeat.getStatus() == MySQLHeartbeatStatus.OK) { // ok->ok
             if (!heartbeat.getSource().isSalveOrRead() && source.isReadOnly()) { // writehost checkRecoverFail read only status is back?
                 GetAndSyncDbInstanceKeyVariables task = new GetAndSyncDbInstanceKeyVariables(source, true);
                 KeyVariables variables = task.call();
@@ -130,7 +130,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
                     return true;
                 }
             }
-        } else if (heartbeat.getStatus() != MySQLHeartbeat.TIMEOUT_STATUS) { //error/init ->ok
+        } else if (heartbeat.getStatus() != MySQLHeartbeatStatus.TIMEOUT) { //error/init ->ok
             try {
                 source.testConnection();
             } catch (Exception e) {
@@ -170,7 +170,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
                     AlertUtil.alertResolve(AlarmCode.DB_INSTANCE_LOWER_CASE_ERROR, Alert.AlertLevel.WARN, "mysql", this.heartbeat.getSource().getConfig().getId(), labels,
                             ToResolveContainer.DB_INSTANCE_LOWER_CASE_ERROR, url);
                 }
-                if (heartbeat.getStatus() == MySQLHeartbeat.INIT_STATUS || !source.isSalveOrRead()) { // writehost checkRecoverFail read only
+                if (heartbeat.getStatus() == MySQLHeartbeatStatus.INIT || !source.isSalveOrRead()) { // writehost checkRecoverFail read only
                     source.setReadOnly(variables.isReadOnly());
                 }
             }
@@ -203,7 +203,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
         }
         heartbeat.getAsyncRecorder().setBySlaveStatus(resultResult);
         if (checkRecoverFail(source)) return;
-        heartbeat.setResult(MySQLHeartbeat.OK_STATUS);
+        heartbeat.setResult(MySQLHeartbeatStatus.OK);
     }
 
     private void setStatusByReadOnly(PhysicalDbInstance source, Map<String, String> resultResult) {
@@ -217,7 +217,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
             source.setReadOnly(true);
         }
         if (checkRecoverFail(source)) return;
-        heartbeat.setResult(MySQLHeartbeat.OK_STATUS);
+        heartbeat.setResult(MySQLHeartbeatStatus.OK);
     }
 
     public void close() {

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeatStatus.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeatStatus.java
@@ -1,0 +1,5 @@
+package com.actiontech.dble.backend.heartbeat;
+
+public enum MySQLHeartbeatStatus {
+    INIT(), OK(), ERROR(), TIMEOUT(), STOP()
+}

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeatStatus.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeatStatus.java
@@ -1,5 +1,11 @@
 package com.actiontech.dble.backend.heartbeat;
 
 public enum MySQLHeartbeatStatus {
-    INIT(), OK(), ERROR(), TIMEOUT(), STOP()
+    INIT(), OK(), ERROR(), TIMEOUT(), STOP();
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase();
+    }
+
 }

--- a/src/main/java/com/actiontech/dble/cluster/logic/HAClusterLogic.java
+++ b/src/main/java/com/actiontech/dble/cluster/logic/HAClusterLogic.java
@@ -78,7 +78,7 @@ public class HAClusterLogic extends AbstractClusterLogic {
 
     public void syncDbGroupStatusToCluster() throws Exception {
         LOGGER.info("syncDbGroupStatusToCluster start");
-        HaConfigManager.getInstance().init();
+        HaConfigManager.getInstance().init(false);
         Map<String, RawJson> map = HaConfigManager.getInstance().getSourceJsonList();
         for (Map.Entry<String, RawJson> entry : map.entrySet()) {
             clusterHelper.setKV(ClusterMetaUtil.getHaStatusPath(entry.getKey()), entry.getValue());

--- a/src/main/java/com/actiontech/dble/config/ServerConfig.java
+++ b/src/main/java/com/actiontech/dble/config/ServerConfig.java
@@ -364,11 +364,6 @@ public class ServerConfig {
                 LOGGER.warn(checkResult);
                 throw new SQLNonTransientException(checkResult, "HY000", ErrorCode.ER_DOING_DDL);
             }
-            try {
-                HaConfigManager.getInstance().init();
-            } catch (Exception e) {
-                throw new SQLNonTransientException("HaConfigManager init failed", "HY000", ErrorCode.ER_YES);
-            }
             // old dbGroup
             // 1 stop heartbeat
             // 2 backup
@@ -401,6 +396,11 @@ public class ServerConfig {
             this.dbConfig = dbJsonConfig;
             this.shardingConfig = shardingJsonConfig;
             this.sequenceConfig = sequenceJsonConfig;
+            try {
+                HaConfigManager.getInstance().init(true);
+            } catch (Exception e) {
+                throw new SQLNonTransientException("HaConfigManager init failed", "HY000", ErrorCode.ER_YES);
+            }
             CacheService.getInstance().clearCache();
             this.changing = false;
             if (isFullyConfigured) {

--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbInstance.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbInstance.java
@@ -26,7 +26,6 @@ import com.actiontech.dble.config.util.ConfigException;
 import com.actiontech.dble.meta.ColumnMeta;
 import com.actiontech.dble.services.manager.information.ManagerSchemaInfo;
 import com.actiontech.dble.services.manager.information.ManagerWritableTable;
-import com.actiontech.dble.services.manager.response.ShowHeartbeat;
 import com.actiontech.dble.util.DecryptUtil;
 import com.actiontech.dble.util.IntegerUtil;
 import com.actiontech.dble.util.ResourceUtil;
@@ -113,7 +112,7 @@ public class DbleDbInstance extends ManagerWritableTable {
     private static final String COLUMN_FLOW_LOW_LEVEL = "flow_low_level";
 
     public DbleDbInstance() {
-        super(TABLE_NAME, 30);
+        super(TABLE_NAME, 33);
         setNotWritableColumnSet(COLUMN_ACTIVE_CONN_COUNT, COLUMN_IDLE_CONN_COUNT, COLUMN_READ_CONN_REQUEST, COLUMN_WRITE_CONN_REQUEST,
                 COLUMN_LAST_HEARTBEAT_ACK_TIMESTAMP, COLUMN_LAST_HEARTBEAT_ACK, COLUMN_HEARTBEAT_STATUS, COLUMN_HEARTBEAT_FAILURE_IN_LAST_5MIN);
 
@@ -251,7 +250,7 @@ public class DbleDbInstance extends ManagerWritableTable {
                 map.put(COLUMN_WRITE_CONN_REQUEST, String.valueOf(dbInstance.getCount(false)));
                 map.put(COLUMN_DISABLED, String.valueOf(dbInstance.isDisabled()));
                 map.put(COLUMN_LAST_HEARTBEAT_ACK_TIMESTAMP, heartbeat.getLastActiveTime());
-                map.put(COLUMN_LAST_HEARTBEAT_ACK, ShowHeartbeat.getRdCode(heartbeat.getStatus()));
+                map.put(COLUMN_LAST_HEARTBEAT_ACK, heartbeat.getStatus().toString());
                 map.put(COLUMN_HEARTBEAT_STATUS, heartbeat.isChecking() ? MySQLHeartbeat.CHECK_STATUS_CHECKING : MySQLHeartbeat.CHECK_STATUS_IDLE);
                 map.put(COLUMN_HEARTBEAT_FAILURE_IN_LAST_5MIN, String.valueOf(heartbeat.getErrorTimeInLast5MinCount()));
                 map.put(COLUMN_MIN_CONN_COUNT, String.valueOf(dbInstanceConfig.getMinCon()));

--- a/src/main/java/com/actiontech/dble/services/manager/response/ShowHeartbeat.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/ShowHeartbeat.java
@@ -117,8 +117,8 @@ public final class ShowHeartbeat {
                 if (hb != null) {
                     row.add(ds.getConfig().getIp().getBytes());
                     row.add(IntegerUtil.toBytes(ds.getConfig().getPort()));
-                    String code = getRdCode(hb.getStatus());
-                    row.add(code == null ? null : code.getBytes());
+                    String code = hb.getStatus().toString();
+                    row.add(code.getBytes());
                     row.add(IntegerUtil.toBytes(hb.getErrorCount()));
                     row.add(hb.isChecking() ? "checking".getBytes() : "idle".getBytes());
                     row.add(LongUtil.toBytes(hb.getHeartbeatTimeout()));
@@ -144,26 +144,4 @@ public final class ShowHeartbeat {
         }
         return list;
     }
-
-    public static String getRdCode(int status) {
-        String code = null;
-        switch (status) {
-            case 0:
-                code = "init";
-                break;
-            case 1:
-                code = "ok";
-                break;
-            case -1:
-                code = "error";
-                break;
-            case -2:
-                code = "time_out";
-                break;
-            default:
-                break;
-        }
-        return code;
-    }
-
 }

--- a/src/main/java/com/actiontech/dble/singleton/HaConfigManager.java
+++ b/src/main/java/com/actiontech/dble/singleton/HaConfigManager.java
@@ -14,6 +14,7 @@ import com.actiontech.dble.cluster.zkprocess.entity.dbGroups.DBGroup;
 import com.actiontech.dble.cluster.zkprocess.entity.dbGroups.DBInstance;
 import com.actiontech.dble.cluster.zkprocess.parse.XmlProcessBase;
 import com.actiontech.dble.config.ConfigFileName;
+import com.actiontech.dble.config.converter.DBConverter;
 import com.actiontech.dble.config.util.DbXmlWriteJob;
 import com.actiontech.dble.util.ResourceUtil;
 import com.google.gson.Gson;
@@ -57,12 +58,17 @@ public final class HaConfigManager {
         }
     }
 
-    public void init() throws Exception {
-        try {
-            INSTANCE.dbGroups = (DbGroups) xmlProcess.baseParseXmlToBean(ConfigFileName.DB_XML, ConfigFileName.DB_XSD);
-        } catch (Exception e) {
-            HA_LOGGER.warn("DbParseXmlImpl parseXmlToBean JAXBException", e);
-            throw e;
+    public void init(boolean isMemory) throws Exception {
+        if (isMemory) {
+            RawJson dbConfig = DbleServer.getInstance().getConfig().getDbConfig();
+            INSTANCE.dbGroups = new DBConverter().dbJsonToBean(dbConfig, false);
+        } else {
+            try {
+                INSTANCE.dbGroups = (DbGroups) xmlProcess.baseParseXmlToBean(ConfigFileName.DB_XML, ConfigFileName.DB_XSD);
+            } catch (Exception e) {
+                HA_LOGGER.warn("DbParseXmlImpl parseXmlToBean JAXBException", e);
+                throw e;
+            }
         }
         reloadIndex.incrementAndGet();
         //try to clear the waiting list and


### PR DESCRIPTION
Reason:
  BUG inner-1847、inner-1874
Type:
  BUG
Influences：
fix: newly added instance needs to create a connection pool immediately #3357
heartbeat status is STOP_STATUS after ha disable
fix: config is synced to ha's memory #3359
fix: use lowercase for status #3366