### PR TITLE
fix: newly added instance needs to create a connection pool immediately(cherry-pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/DbleServer.java
+++ b/src/main/java/com/actiontech/dble/DbleServer.java
@@ -119,7 +119,7 @@ public final class DbleServer {
         LOGGER.info("=========================================Config file read finish==================================");
 
         LOGGER.info("=========================================Init Outer Ha Config==================================");
-        HaConfigManager.getInstance().init();
+        HaConfigManager.getInstance().init(false);
 
         if (SystemConfig.getInstance().getEnableAlert() == 1) {
             AlertUtil.switchAlert(true);

--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbGroup.java
@@ -358,9 +358,22 @@ public class PhysicalDbGroup {
             }
 
             if (ds.isAlive() && (!checkSlaveSynStatus() || ds.canSelectAsReadNode())) {
+                if (ds.getLogCount() != 0) {
+                    ds.setLogCount(0);
+                }
                 okSources.add(ds);
             } else {
-                LOGGER.warn("can't select dbInstance[{}] as read node, please check delay with primary", ds);
+                if (ds.isAlive()) {
+                    if (ds.getLogCount() != 0) {
+                        ds.setLogCount(0);
+                    }
+                    LOGGER.warn("can't select dbInstance[{}] as read node, please check delay with primary", ds);
+                } else {
+                    if (ds.getLogCount() < 10) {
+                        ds.setLogCount(ds.getLogCount() + 1);
+                        LOGGER.warn("can't select dbInstance[{}] as read node, please check the disabled and heartbeat status", ds);
+                    }
+                }
             }
         }
         if (okSources.size() == 0 && rwSplitMode == RW_SPLIT_ALL_SLAVES_MAY_MASTER && includeWrite) {

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDetector.java
@@ -106,7 +106,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
 
     private void setStatusForNormalHeartbeat(PhysicalDbInstance source) {
         if (checkRecoverFail(source)) return;
-        heartbeat.setResult(MySQLHeartbeat.OK_STATUS);
+        heartbeat.setResult(MySQLHeartbeatStatus.OK);
     }
 
     /**
@@ -117,7 +117,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
             LOGGER.warn("heartbeat[{}] had been stop", source.getConfig().getUrl());
             return true;
         }
-        if (heartbeat.getStatus() == MySQLHeartbeat.OK_STATUS) { // ok->ok
+        if (heartbeat.getStatus() == MySQLHeartbeatStatus.OK) { // ok->ok
             if (!heartbeat.getSource().isSalveOrRead() && source.isReadOnly()) { // writehost checkRecoverFail read only status is back?
                 GetAndSyncDbInstanceKeyVariables task = new GetAndSyncDbInstanceKeyVariables(source, true);
                 KeyVariables variables = task.call();
@@ -129,7 +129,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
                     return true;
                 }
             }
-        } else if (heartbeat.getStatus() != MySQLHeartbeat.TIMEOUT_STATUS) { //error/init ->ok
+        } else if (heartbeat.getStatus() != MySQLHeartbeatStatus.TIMEOUT) { //error/init ->ok
             try {
                 source.testConnection();
             } catch (Exception e) {
@@ -169,7 +169,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
                     AlertUtil.alertResolve(AlarmCode.DB_INSTANCE_LOWER_CASE_ERROR, Alert.AlertLevel.WARN, "mysql", this.heartbeat.getSource().getConfig().getId(), labels,
                             ToResolveContainer.DB_INSTANCE_LOWER_CASE_ERROR, url);
                 }
-                if (heartbeat.getStatus() == MySQLHeartbeat.INIT_STATUS || !source.isSalveOrRead()) { // writehost checkRecoverFail read only
+                if (heartbeat.getStatus() == MySQLHeartbeatStatus.INIT || !source.isSalveOrRead()) { // writehost checkRecoverFail read only
                     source.setReadOnly(variables.isReadOnly());
                 }
             }
@@ -202,7 +202,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
         }
         heartbeat.getAsyncRecorder().setBySlaveStatus(resultResult);
         if (checkRecoverFail(source)) return;
-        heartbeat.setResult(MySQLHeartbeat.OK_STATUS);
+        heartbeat.setResult(MySQLHeartbeatStatus.OK);
     }
 
     private void setStatusByReadOnly(PhysicalDbInstance source, Map<String, String> resultResult) {
@@ -216,7 +216,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
             source.setReadOnly(true);
         }
         if (checkRecoverFail(source)) return;
-        heartbeat.setResult(MySQLHeartbeat.OK_STATUS);
+        heartbeat.setResult(MySQLHeartbeatStatus.OK);
     }
 
     public void close() {

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeat.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeat.java
@@ -35,16 +35,12 @@ public class MySQLHeartbeat {
     public static final String CHECK_STATUS_CHECKING = "checking";
     public static final String CHECK_STATUS_IDLE = "idle";
 
-    public static final int INIT_STATUS = 0;
-    public static final int OK_STATUS = 1;
-    private static final int ERROR_STATUS = -1;
-    static final int TIMEOUT_STATUS = -2;
     private final int errorRetryCount;
     private final AtomicBoolean isChecking = new AtomicBoolean(false);
     private final HeartbeatRecorder recorder = new HeartbeatRecorder();
     private final DbInstanceSyncRecorder asyncRecorder = new DbInstanceSyncRecorder();
     private final PhysicalDbInstance source;
-    protected volatile int status;
+    protected volatile MySQLHeartbeatStatus status;
     private String heartbeatSQL;
     private long heartbeatTimeout; // during the time, heart failed will ignore
     private final AtomicInteger errorCount = new AtomicInteger(0);
@@ -60,7 +56,7 @@ public class MySQLHeartbeat {
 
     public MySQLHeartbeat(PhysicalDbInstance dbInstance) {
         this.source = dbInstance;
-        this.status = INIT_STATUS;
+        this.status = MySQLHeartbeatStatus.INIT;
         this.errorRetryCount = dbInstance.getDbGroupConfig().getErrorRetryCount();
         this.heartbeatTimeout = dbInstance.getDbGroupConfig().getHeartbeatTimeout();
         this.heartbeatSQL = dbInstance.getDbGroupConfig().getHeartbeatSQL();
@@ -99,7 +95,7 @@ public class MySQLHeartbeat {
         LOGGER.info("stop heartbeat of instance[{}], due to {}", source.getConfig().getUrl(), reason);
         isStop = true;
         scheduledFuture.cancel(false);
-        this.status = INIT_STATUS;
+        this.status = MySQLHeartbeatStatus.STOP;
         if (detector != null && !detector.isQuit()) {
             detector.quit();
             isChecking.set(false);
@@ -120,7 +116,7 @@ public class MySQLHeartbeat {
                 if (detector.isQuit()) {
                     isChecking.set(false);
                 } else if (detector.isHeartbeatTimeout()) {
-                    setResult(TIMEOUT_STATUS);
+                    setResult(MySQLHeartbeatStatus.TIMEOUT);
                 }
             }
         }
@@ -155,7 +151,7 @@ public class MySQLHeartbeat {
         }
         this.isChecking.set(false);
         this.message = errMsg;
-        this.status = ERROR_STATUS;
+        this.status = MySQLHeartbeatStatus.ERROR;
         startErrorTime.compareAndSet(-1, System.currentTimeMillis());
         Map<String, String> labels = AlertUtil.genSingleLabel("dbInstance", this.source.getDbGroupConfig().getName() + "-" + this.source.getConfig().getInstanceName());
         AlertUtil.alert(AlarmCode.HEARTBEAT_FAIL, Alert.AlertLevel.WARN, "heartbeat status:" + this.status, "mysql", this.source.getConfig().getId(), labels);
@@ -166,20 +162,20 @@ public class MySQLHeartbeat {
         }
     }
 
-    void setResult(int result) {
+    void setResult(MySQLHeartbeatStatus result) {
         this.isChecking.set(false);
         this.message = null;
         switch (result) {
-            case OK_STATUS:
+            case OK:
                 setOk();
                 break;
-            case TIMEOUT_STATUS:
+            case TIMEOUT:
                 setTimeout();
                 break;
             default:
                 break;
         }
-        if (this.status != OK_STATUS) {
+        if (this.status != MySQLHeartbeatStatus.OK) {
             Map<String, String> labels = AlertUtil.genSingleLabel("dbInstance", this.source.getDbGroupConfig().getName() + "-" + this.source.getConfig().getInstanceName());
             AlertUtil.alert(AlarmCode.HEARTBEAT_FAIL, Alert.AlertLevel.WARN, "heartbeat status:" + this.status, "mysql", this.source.getConfig().getId(), labels);
         }
@@ -190,8 +186,8 @@ public class MySQLHeartbeat {
             LOGGER.debug("heartbeat to [" + source.getConfig().getUrl() + "] setOK");
         }
         switch (status) {
-            case TIMEOUT_STATUS:
-                this.status = INIT_STATUS;
+            case TIMEOUT:
+                this.status = MySQLHeartbeatStatus.INIT;
                 this.errorCount.set(0);
                 this.startErrorTime.set(-1);
                 if (isStop) {
@@ -202,15 +198,19 @@ public class MySQLHeartbeat {
                     heartbeat(); // timeout, heart beat again
                 }
                 break;
-            case OK_STATUS:
+            case OK:
                 break;
             default:
                 LOGGER.info("heartbeat to [{}] setOk, previous status is {}", source.getConfig().getUrl(), status);
-                this.status = OK_STATUS;
+                this.status = MySQLHeartbeatStatus.OK;
                 this.errorCount.set(0);
                 this.startErrorTime.set(-1);
                 Map<String, String> labels = AlertUtil.genSingleLabel("dbInstance", this.source.getDbGroupConfig().getName() + "-" + this.source.getConfig().getInstanceName());
                 AlertUtil.alertResolve(AlarmCode.HEARTBEAT_FAIL, Alert.AlertLevel.WARN, "mysql", this.source.getConfig().getId(), labels);
+        }
+        //after the heartbeat changes from failure to success, it needs to be expanded immediately
+        if (source.getTotalConnections() == 0) {
+            source.updatePoolCapacity();
         }
         if (isStop) {
             LOGGER.warn("heartbeat[{}] had been stop", source.getConfig().getUrl());
@@ -232,16 +232,16 @@ public class MySQLHeartbeat {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("heartbeat to [" + source.getConfig().getUrl() + "] setTimeout");
         }
-        if (status != TIMEOUT_STATUS) {
+        if (status != MySQLHeartbeatStatus.TIMEOUT) {
             LOGGER.warn("heartbeat to [{}] setTimeout, previous status is {}", source.getConfig().getUrl(), status);
-            status = TIMEOUT_STATUS;
+            status = MySQLHeartbeatStatus.TIMEOUT;
         }
     }
 
     public boolean isHeartBeatOK() {
-        if (status == OK_STATUS || status == INIT_STATUS) {
+        if (status == MySQLHeartbeatStatus.OK || status == MySQLHeartbeatStatus.INIT) {
             return true;
-        } else if (status == ERROR_STATUS) {
+        } else if (status == MySQLHeartbeatStatus.ERROR) {
             long timeDiff = System.currentTimeMillis() - this.startErrorTime.longValue();
             if (timeDiff >= heartbeatTimeout) {
                 if (LOGGER.isDebugEnabled()) {
@@ -250,7 +250,7 @@ public class MySQLHeartbeat {
                 return false;
             }
             return true;
-        } else { // TIMEOUT_STATUS
+        } else { // TIMEOUT or STOP
             return false;
         }
     }
@@ -271,7 +271,7 @@ public class MySQLHeartbeat {
         this.dbSynStatus = dbSynStatus;
     }
 
-    public int getStatus() {
+    public MySQLHeartbeatStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeatStatus.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLHeartbeatStatus.java
@@ -1,0 +1,11 @@
+package com.actiontech.dble.backend.heartbeat;
+
+public enum MySQLHeartbeatStatus {
+    INIT(), OK(), ERROR(), TIMEOUT(), STOP();
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase();
+    }
+
+}

--- a/src/main/java/com/actiontech/dble/backend/pool/ConnectionPool.java
+++ b/src/main/java/com/actiontech/dble/backend/pool/ConnectionPool.java
@@ -174,7 +174,7 @@ public class ConnectionPool extends PoolBase implements PooledConnectionListener
         }
     }
 
-    private void fillPool() {
+    public void fillPool() {
         final int idleCount = getCount(STATE_NOT_IN_USE, STATE_HEARTBEAT);
         int tmpTotalConnections = totalConnections.get();
         if (tmpTotalConnections < 0) {
@@ -374,6 +374,33 @@ public class ConnectionPool extends PoolBase implements PooledConnectionListener
             } else if (poolConfig.getTestWhileIdle() && conn.compareAndSet(STATE_NOT_IN_USE, STATE_HEARTBEAT)) {
                 ConnectionHeartBeatHandler heartBeatHandler = new ConnectionHeartBeatHandler((BackendConnection) conn, false, this);
                 heartBeatHandler.ping(poolConfig.getConnectionHeartbeatTimeout());
+            }
+        }
+
+    }
+
+    public void evictImmediately() {
+
+        final ArrayList<PooledConnection> idleList = new ArrayList<>(allConnections.size());
+        for (final PooledConnection entry : allConnections) {
+            if (entry.getState() == STATE_NOT_IN_USE) {
+                idleList.add(entry);
+            }
+        }
+
+        int removable = idleList.size() - config.getMinCon();
+        if (removable <= 0) {
+            return;
+        }
+
+        // Sort pool entries on lastAccessed
+        idleList.sort(LAST_ACCESS_COMPARABLE);
+
+        logPoolState("before cleanup ");
+        for (PooledConnection conn : idleList) {
+            if (removable > 0 && conn.compareAndSet(STATE_NOT_IN_USE, STATE_RESERVED)) {
+                conn.close("connection has passed idleTimeout");
+                removable--;
             }
         }
 

--- a/src/main/java/com/actiontech/dble/cluster/ClusterLogic.java
+++ b/src/main/java/com/actiontech/dble/cluster/ClusterLogic.java
@@ -949,7 +949,7 @@ public final class ClusterLogic {
 
     public static void syncDbGroupStatusToCluster() throws Exception {
         LOGGER.info("syncDbGroupStatusToCluster start");
-        HaConfigManager.getInstance().init();
+        HaConfigManager.getInstance().init(false);
         Map<String, String> map = HaConfigManager.getInstance().getSourceJsonList();
         for (Map.Entry<String, String> entry : map.entrySet()) {
             ClusterHelper.setKV(ClusterPathUtil.getHaStatusPath(entry.getKey()), entry.getValue());

--- a/src/main/java/com/actiontech/dble/config/ServerConfig.java
+++ b/src/main/java/com/actiontech/dble/config/ServerConfig.java
@@ -352,11 +352,6 @@ public class ServerConfig {
                 LOGGER.warn(checkResult);
                 throw new SQLNonTransientException(checkResult, "HY000", ErrorCode.ER_DOING_DDL);
             }
-            try {
-                HaConfigManager.getInstance().init();
-            } catch (Exception e) {
-                throw new SQLNonTransientException("HaConfigManager init failed", "HY000", ErrorCode.ER_YES);
-            }
             // old dbGroup
             // 1 stop heartbeat
             // 2 backup
@@ -388,6 +383,11 @@ public class ServerConfig {
             this.dbConfig = dbJsonConfig;
             this.shardingConfig = shardingJsonConfig;
             this.sequenceConfig = sequenceJsonConfig;
+            try {
+                HaConfigManager.getInstance().init(true);
+            } catch (Exception e) {
+                throw new SQLNonTransientException("HaConfigManager init failed", "HY000", ErrorCode.ER_YES);
+            }
             CacheService.getInstance().clearCache();
             this.changing = false;
             if (isFullyConfigured) {

--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbInstance.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbInstance.java
@@ -24,7 +24,6 @@ import com.actiontech.dble.config.util.ConfigException;
 import com.actiontech.dble.meta.ColumnMeta;
 import com.actiontech.dble.services.manager.information.ManagerSchemaInfo;
 import com.actiontech.dble.services.manager.information.ManagerWritableTable;
-import com.actiontech.dble.services.manager.response.ShowHeartbeat;
 import com.actiontech.dble.util.DecryptUtil;
 import com.actiontech.dble.util.IntegerUtil;
 import com.actiontech.dble.util.ResourceUtil;
@@ -107,7 +106,7 @@ public class DbleDbInstance extends ManagerWritableTable {
     private static final String COLUMN_HEARTBEAT_PERIOD_MILLIS = "heartbeat_period_millis";
 
     public DbleDbInstance() {
-        super(TABLE_NAME, 30);
+        super(TABLE_NAME, 33);
         setNotWritableColumnSet(COLUMN_ACTIVE_CONN_COUNT, COLUMN_IDLE_CONN_COUNT, COLUMN_READ_CONN_REQUEST, COLUMN_WRITE_CONN_REQUEST,
                 COLUMN_LAST_HEARTBEAT_ACK_TIMESTAMP, COLUMN_LAST_HEARTBEAT_ACK, COLUMN_HEARTBEAT_STATUS, COLUMN_HEARTBEAT_FAILURE_IN_LAST_5MIN);
 
@@ -238,7 +237,7 @@ public class DbleDbInstance extends ManagerWritableTable {
                 map.put(COLUMN_WRITE_CONN_REQUEST, String.valueOf(dbInstance.getCount(false)));
                 map.put(COLUMN_DISABLED, String.valueOf(dbInstance.isDisabled()));
                 map.put(COLUMN_LAST_HEARTBEAT_ACK_TIMESTAMP, heartbeat.getLastActiveTime());
-                map.put(COLUMN_LAST_HEARTBEAT_ACK, ShowHeartbeat.getRdCode(heartbeat.getStatus()));
+                map.put(COLUMN_LAST_HEARTBEAT_ACK, heartbeat.getStatus().toString());
                 map.put(COLUMN_HEARTBEAT_STATUS, heartbeat.isChecking() ? MySQLHeartbeat.CHECK_STATUS_CHECKING : MySQLHeartbeat.CHECK_STATUS_IDLE);
                 map.put(COLUMN_HEARTBEAT_FAILURE_IN_LAST_5MIN, String.valueOf(heartbeat.getErrorTimeInLast5MinCount()));
                 map.put(COLUMN_MIN_CONN_COUNT, String.valueOf(dbInstanceConfig.getMinCon()));

--- a/src/main/java/com/actiontech/dble/services/manager/response/ShowHeartbeat.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/ShowHeartbeat.java
@@ -117,8 +117,8 @@ public final class ShowHeartbeat {
                 if (hb != null) {
                     row.add(ds.getConfig().getIp().getBytes());
                     row.add(IntegerUtil.toBytes(ds.getConfig().getPort()));
-                    String code = getRdCode(hb.getStatus());
-                    row.add(code == null ? null : code.getBytes());
+                    String code = hb.getStatus().toString();
+                    row.add(code.getBytes());
                     row.add(IntegerUtil.toBytes(hb.getErrorCount()));
                     row.add(hb.isChecking() ? "checking".getBytes() : "idle".getBytes());
                     row.add(LongUtil.toBytes(hb.getHeartbeatTimeout()));
@@ -144,26 +144,4 @@ public final class ShowHeartbeat {
         }
         return list;
     }
-
-    public static String getRdCode(int status) {
-        String code = null;
-        switch (status) {
-            case 0:
-                code = "init";
-                break;
-            case 1:
-                code = "ok";
-                break;
-            case -1:
-                code = "error";
-                break;
-            case -2:
-                code = "time_out";
-                break;
-            default:
-                break;
-        }
-        return code;
-    }
-
 }

--- a/src/main/java/com/actiontech/dble/singleton/HaConfigManager.java
+++ b/src/main/java/com/actiontech/dble/singleton/HaConfigManager.java
@@ -11,6 +11,7 @@ import com.actiontech.dble.cluster.zkprocess.entity.dbGroups.DBGroup;
 import com.actiontech.dble.cluster.zkprocess.entity.dbGroups.DBInstance;
 import com.actiontech.dble.cluster.zkprocess.parse.XmlProcessBase;
 import com.actiontech.dble.config.ConfigFileName;
+import com.actiontech.dble.config.converter.DBConverter;
 import com.actiontech.dble.config.util.DbXmlWriteJob;
 import com.actiontech.dble.util.ResourceUtil;
 import com.google.gson.Gson;
@@ -55,12 +56,17 @@ public final class HaConfigManager {
         }
     }
 
-    public void init() throws Exception {
-        try {
-            INSTANCE.dbGroups = (DbGroups) xmlProcess.baseParseXmlToBean(ConfigFileName.DB_XML, ConfigFileName.DB_XSD);
-        } catch (Exception e) {
-            HA_LOGGER.warn("DbParseXmlImpl parseXmlToBean JAXBException", e);
-            throw e;
+    public void init(boolean isMemory) throws Exception {
+        if (isMemory) {
+            String dbConfig = DbleServer.getInstance().getConfig().getDbConfig();
+            INSTANCE.dbGroups = new DBConverter().dbJsonToBean(dbConfig, false);
+        } else {
+            try {
+                INSTANCE.dbGroups = (DbGroups) xmlProcess.baseParseXmlToBean(ConfigFileName.DB_XML, ConfigFileName.DB_XSD);
+            } catch (Exception e) {
+                HA_LOGGER.warn("DbParseXmlImpl parseXmlToBean JAXBException", e);
+                throw e;
+            }
         }
         reloadIndex.incrementAndGet();
         //try to clear the waiting list and


### PR DESCRIPTION
Reason:
  BUG inner-1847、inner-1874
Type:
  BUG
Influences：
fix: newly added instance needs to create a connection pool immediately #3357
heartbeat status is STOP_STATUS after ha disable
fix: config is synced to ha's memory #3359
fix: use lowercase for status #3366