### PR TITLE
inner 1980 - keep respHandler and responseHandler in MySQLConnectionHandler consistent

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/nio/MySQLConnection.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/nio/MySQLConnection.java
@@ -707,7 +707,7 @@ public class MySQLConnection extends AbstractConnection implements
      */
     @Override
     public synchronized void closeWithoutRsp(String reason) {
-        this.respHandler = null;
+        setResponseHandler(null);
         this.close(reason);
     }
 


### PR DESCRIPTION
Reason:  
  BUG #inner 1980. 
Type:  
  BUG
Influences：  
  keep respHandler and responseHandler in MySQLConnectionHandler consistent
