### PR TITLE
fix: add the determination of whether ssl is enabled（cherry-pick）

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/mysql/proto/handler/Impl/MySQLProtoHandlerImpl.java
+++ b/src/main/java/com/actiontech/dble/backend/mysql/proto/handler/Impl/MySQLProtoHandlerImpl.java
@@ -7,6 +7,7 @@ package com.actiontech.dble.backend.mysql.proto.handler.Impl;
 
 import com.actiontech.dble.backend.mysql.proto.handler.ProtoHandler;
 import com.actiontech.dble.backend.mysql.proto.handler.ProtoHandlerResult;
+import com.actiontech.dble.config.model.SystemConfig;
 import com.actiontech.dble.net.mysql.MySQLPacket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,7 @@ public class MySQLProtoHandlerImpl implements ProtoHandler {
             // not read whole message package ,so check if buffer enough and
             // compact dataBuffer
             if (!dataBuffer.hasRemaining()) {
-                if (SSLProtoHandler.isSSLPackage(dataBuffer, offset)) {
+                if (SystemConfig.getInstance().isSupportSSL() && SSLProtoHandler.isSSLPackage(dataBuffer, offset)) {
                     return builder.setCode(SSL_PROTO_PACKET).setHasMorePacket(false).setOffset(offset);
                 }
                 return builder.setCode(BUFFER_NOT_BIG_ENOUGH).setHasMorePacket(false).setOffset(offset).setPacketLength(length);

--- a/src/main/java/com/actiontech/dble/net/connection/AbstractConnection.java
+++ b/src/main/java/com/actiontech/dble/net/connection/AbstractConnection.java
@@ -120,8 +120,13 @@ public abstract class AbstractConnection implements Connection {
         } else {
             netInBytes += got;
         }
+
         final ByteBuffer tmpReadBuffer = getReadBuffer();
         if (tmpReadBuffer != null) {
+            if (got == 0 && tmpReadBuffer.position() != 0 && tmpReadBuffer.position() == tmpReadBuffer.limit()) {
+                //The buffer is full, but has not been read
+                throw new IllegalStateException("there is a problem with buffer reading");
+            }
             handle(tmpReadBuffer);
         } else if (!isClosed()) {
             //generally,it's won't happen


### PR DESCRIPTION
Reason:
  BUG inner-2028
Type:
  BUG
Influences：
fix: add the determination of whether ssl is enabled
when the buffer is always full but no new data has been read, an error needs to be reported
#3505