### PR TITLE
fix: not display note-level warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: +security-and-quality
+        queries: security-extended
 
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).


### PR DESCRIPTION
Reason:  
  Improve    
Type:  
  Improve  
Influences：  
fix: not display note-level warnings
