### PR TITLE
Inner 711&631: fixed:multi-query cause timeout and 'CALL' query causes hang(cherry-pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/server/parser/RwSplitServerParse.java
+++ b/src/main/java/com/actiontech/dble/server/parser/RwSplitServerParse.java
@@ -128,6 +128,12 @@ public final class RwSplitServerParse extends ServerParse {
         return rt;
     }
 
+
+    public static boolean isMultiStatement(String sql) {
+        int index = ParseUtil.findNextBreak(sql);
+        return index + 1 < sql.length() && !ParseUtil.isEOF(sql, index);
+    }
+
     // INSERT' ' | INSTALL '  '
     protected static int iCheck(String stmt, int offset) {
         int type = OTHER;


### PR DESCRIPTION
Reason:
  In RwSplit scenarios, when using JDBC with URL param allowMultiQueries, send multi-query cause timeout.Error reports:(2013, 'Lost connection to MySQL server during query')
Type:
  BUG inner-711
Influences：
   fixed.

Reason:
  In RwSplit scenarios, the CALL query causes hang.
Type:
  BUG inner-631
Influences：
   fixed.