### PR TITLE
upgrade log4j2 to 2.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             UTF-8
         </project.build.sourceEncoding>
         <grpc.version>1.4.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.18.0</log4j2.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
Reason:  
  Improve.  
Type:  
  Improve  
Influences：  
  upgrade log4j2 to 2.18.0
