### PR TITLE
[inner-2095] Log4j upgrade to 2.18.0 version (#3605)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
             UTF-8
         </project.build.sourceEncoding>
         <grpc.version>1.5.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.18.0</log4j2.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
Reason:  
  BUG inner 2095 ,similar #3605 
Type:  
  BUG/Improve  
Influences：  
   fix xx
