### PR TITLE
fix: the timing of obtaining the number of waiting threads in the connection pool is wrong

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/pool/ConnectionPool.java
+++ b/src/main/java/com/actiontech/dble/backend/pool/ConnectionPool.java
@@ -81,9 +81,10 @@ public class ConnectionPool extends PoolBase implements PooledConnectionListener
         try {
             ConnectionPoolProvider.getConnGetFrenshLocekAfter();
             ConnectionPoolProvider.borrowDirectlyConnectionBefore();
-            int waiting = waiters.get();
             for (PooledConnection conn : allConnections) {
                 if (conn.compareAndSet(STATE_NOT_IN_USE, STATE_IN_USE)) {
+                    final int waiting = waiterNum;
+                    ConnectionPoolProvider.getWaiterCountAfter();
                     if (waiting > 0 && conn.getCreateByWaiter().compareAndSet(true, false)) {
                         ConnectionPoolProvider.newConnectionBorrowDirectly();
                         newPooledEntry(schema, waiting, true);
@@ -103,12 +104,12 @@ public class ConnectionPool extends PoolBase implements PooledConnectionListener
             freshLock.readLock().lock();
         }
         try {
-            final int waiting = waiterNum;
             ConnectionPoolProvider.getConnGetFrenshLocekAfter();
             ConnectionPoolProvider.borrowConnectionBefore();
             for (PooledConnection conn : allConnections) {
                 if (conn.compareAndSet(STATE_NOT_IN_USE, STATE_IN_USE)) {
                     // If we may have stolen another waiter's connection, request another bag add.
+                    final int waiting = waiterNum;
                     if (waiting > 0 && conn.getCreateByWaiter().compareAndSet(true, false)) {
                         ConnectionPoolProvider.newConnectionBorrow0();
                         newPooledEntry(schema, waiting, true);

--- a/src/main/java/com/actiontech/dble/btrace/provider/ConnectionPoolProvider.java
+++ b/src/main/java/com/actiontech/dble/btrace/provider/ConnectionPoolProvider.java
@@ -51,5 +51,9 @@ public final class ConnectionPoolProvider {
 
     }
 
+    public static void getWaiterCountAfter() {
+
+    }
+
 
 }

--- a/src/main/java/com/actiontech/dble/cluster/ClusterController.java
+++ b/src/main/java/com/actiontech/dble/cluster/ClusterController.java
@@ -73,6 +73,10 @@ public final class ClusterController {
             if (Strings.isNullOrEmpty(clusterConfig.getRootPath())) {
                 StartProblemReporter.getInstance().addError("rootPath need to set in cluster.cnf when clusterEnable is true");
             }
+            int grpcTimeout = clusterConfig.getGrpcTimeout();
+            if (grpcTimeout < 1) {
+                StartProblemReporter.getInstance().addError("grpcTimeout should be greater than 1");
+            }
         }
     }
 


### PR DESCRIPTION
Reason:
  BUG inner-1867&inner-2089
Type:
  BUG
Influences：
fix: the timing of obtaining the number of waiting threads in the connection pool is wrong
fix: grpcTimeout parameter validation