### PR TITLE
fix: peel version check module 

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
+++ b/src/main/java/com/actiontech/dble/backend/datasource/PhysicalDbInstance.java
@@ -347,7 +347,7 @@ public abstract class PhysicalDbInstance implements ReadTimeStatusInstance {
         return dsVersion;
     }
 
-    protected void setDsVersion(String dsVersion) {
+    public void setDsVersion(String dsVersion) {
         this.dsVersion = dsVersion;
     }
 

--- a/src/main/java/com/actiontech/dble/config/ServerConfig.java
+++ b/src/main/java/com/actiontech/dble/config/ServerConfig.java
@@ -160,6 +160,7 @@ public class ServerConfig {
     }
 
     public void getAndSyncKeyVariables() throws Exception {
+        ConfigUtil.checkDbleAndMysqlVersion(confInitNew.getDbGroups());
         ConfigUtil.getAndSyncKeyVariables(confInitNew.getDbGroups(), true);
         DbleServer.getInstance().getConfig().setLowerCase(DbleTempConfig.getInstance().isLowerCase());
     }

--- a/src/main/java/com/actiontech/dble/config/util/ConfigUtil.java
+++ b/src/main/java/com/actiontech/dble/config/util/ConfigUtil.java
@@ -10,12 +10,14 @@ import com.actiontech.dble.backend.datasource.PhysicalDbGroup;
 import com.actiontech.dble.backend.datasource.PhysicalDbInstance;
 import com.actiontech.dble.backend.datasource.ShardingNode;
 import com.actiontech.dble.backend.mysql.VersionUtil;
+import com.actiontech.dble.config.ConfigInitializer;
 import com.actiontech.dble.config.DbleTempConfig;
 import com.actiontech.dble.config.helper.GetAndSyncDbInstanceKeyVariables;
 import com.actiontech.dble.config.helper.KeyVariables;
 import com.actiontech.dble.config.model.MysqlVersion;
 import com.actiontech.dble.config.model.SystemConfig;
 import com.actiontech.dble.config.model.db.type.DataBaseType;
+import com.actiontech.dble.config.model.user.RwSplitUserConfig;
 import com.actiontech.dble.services.manager.response.ChangeItem;
 import com.actiontech.dble.services.manager.response.ChangeItemType;
 import com.actiontech.dble.services.manager.response.ChangeType;
@@ -98,7 +100,7 @@ public final class ConfigUtil {
                             changeItem.getType() == ChangeType.ADD) ||
                             (changeItem.getItemType() == ChangeItemType.PHYSICAL_DB_INSTANCE && changeItem.getType() == ChangeType.UPDATE && changeItem.isAffectTestConn()))
                     .collect(Collectors.toList());
-            if (changeItemList.size() == 0 || needCheckItemList == null || needCheckItemList.isEmpty()) {
+            if (changeItemList.size() == 0 || needCheckItemList.isEmpty()) {
                 //with no dbGroups, do not check the variables
                 return null;
             }
@@ -120,10 +122,6 @@ public final class ConfigUtil {
                         diffGroup.add(variableMapKey.getDataSourceName());
                     }
                     minNodePacketSize = Math.min(minNodePacketSize, keyVariables.getMaxPacketSize());
-
-                    PhysicalDbInstance instance = variableMapKey.getDbInstance();
-                    //check mysql version
-                    checkMysqlVersion(keyVariables.getVersion(), instance, true);
                 }
             }
             if (minNodePacketSize < SystemConfig.getInstance().getMaxPacketSize() + KeyVariables.MARGIN_PACKET_SIZE) {
@@ -207,8 +205,6 @@ public final class ConfigUtil {
                 }
                 minNodePacketSize = Math.min(minNodePacketSize, keyVariables.getMaxPacketSize());
                 PhysicalDbInstance instance = variableMapKey.getDbInstance();
-                //check mysql version
-                checkMysqlVersion(keyVariables.getVersion(), instance, true);
 
                 // The back_log value indicates how many requests can be stacked during this short time before MySQL momentarily stops answering new requests
                 int minCon = instance.getConfig().getMinCon();
@@ -261,13 +257,16 @@ public final class ConfigUtil {
         if (!instance.getDbGroup().isRwSplitUseless()) {
             //rw-split
             return checkVersionWithRwSplit(version, instance, isThrowException, type);
-        } else {
+        } else if (!instance.getDbGroup().isShardingUseless() || !instance.getDbGroup().isAnalysisUseless()) {
+            //sharding or analysis
             boolean isMatch = majorVersion >= VersionUtil.getMajorVersion(SystemConfig.getInstance().getFakeMySQLVersion());
             if (!isMatch && isThrowException) {
                 throw new ConfigException("the dble version[=" + SystemConfig.getInstance().getFakeMySQLVersion() + "] cannot be higher than the minimum version of the backend " + type + " node,pls check the backend " + type + " node.");
             }
             return isMatch;
         }
+        //not referenced
+        return true;
     }
 
     /**
@@ -328,10 +327,6 @@ public final class ConfigUtil {
                     secondGroup.add(variableMapKey.getDataSourceName());
                 }
                 minNodePacketSize = Math.min(minNodePacketSize, keyVariables.getMaxPacketSize());
-
-                PhysicalDbInstance instance = variableMapKey.getDbInstance();
-                //check mysql version
-                checkMysqlVersion(keyVariables.getVersion(), instance, true);
             }
         }
         if (minNodePacketSize < SystemConfig.getInstance().getMaxPacketSize() + KeyVariables.MARGIN_PACKET_SIZE) {
@@ -444,6 +439,62 @@ public final class ConfigUtil {
 
     private static String genDataSourceKey(String hostName, String dsName) {
         return hostName + ":" + dsName;
+    }
+
+    public static void checkDbleAndMysqlVersion(List<ChangeItem> changeItemList, ConfigInitializer newConfigLoader) {
+        List<ChangeItem> needCheckVersionList = changeItemList.stream()
+                //add dbInstance or add dbGroup or add shardingNode or (update dbInstance and need testConn) or (update rwSplitUser and affectEntryDbGroup=true) or update shardingNode
+                .filter(changeItem -> ((changeItem.getItemType() == ChangeItemType.PHYSICAL_DB_INSTANCE || changeItem.getItemType() == ChangeItemType.PHYSICAL_DB_GROUP || changeItem.getItemType() == ChangeItemType.SHARDING_NODE) && changeItem.getType() == ChangeType.ADD) ||
+                        (changeItem.getItemType() == ChangeItemType.PHYSICAL_DB_INSTANCE && changeItem.getType() == ChangeType.UPDATE && changeItem.isAffectTestConn()) ||
+                        (changeItem.getItemType() == ChangeItemType.USERNAME && changeItem.getType() == ChangeType.UPDATE && changeItem.isAffectEntryDbGroup()) ||
+                        (changeItem.getItemType() == ChangeItemType.SHARDING_NODE && changeItem.getType() == ChangeType.UPDATE))
+                .collect(Collectors.toList());
+
+        if (changeItemList.size() == 0 || needCheckVersionList.isEmpty()) {
+            //with no item, do not check the version
+            return;
+        }
+        for (ChangeItem changeItem : needCheckVersionList) {
+            Object item = changeItem.getItem();
+            if (changeItem.getItemType() == ChangeItemType.PHYSICAL_DB_INSTANCE) {
+                PhysicalDbInstance ds = (PhysicalDbInstance) item;
+                if (ds.isDisabled() || !ds.isTestConnSuccess() || ds.isFakeNode()) {
+                    continue;
+                }
+                //check mysql version
+                checkMysqlVersion(ds.getDsVersion(), ds, true);
+            } else if (changeItem.getItemType() == ChangeItemType.PHYSICAL_DB_GROUP) {
+                PhysicalDbGroup dbGroup = (PhysicalDbGroup) item;
+                checkDbGroupVersion(dbGroup);
+            } else if (changeItem.getItemType() == ChangeItemType.SHARDING_NODE) {
+                ShardingNode shardingNode = (ShardingNode) item;
+                PhysicalDbGroup dbGroup = shardingNode.getDbGroup();
+                checkDbGroupVersion(dbGroup);
+            } else if (changeItem.getItemType() == ChangeItemType.USERNAME && changeItem.isAffectEntryDbGroup()) {
+                RwSplitUserConfig rwSplitUserConfig = (RwSplitUserConfig) newConfigLoader.getUsers().get(item);
+                PhysicalDbGroup dbGroup = newConfigLoader.getDbGroups().get(rwSplitUserConfig.getDbGroup());
+                checkDbGroupVersion(dbGroup);
+            }
+        }
+    }
+
+    public static void checkDbleAndMysqlVersion(Map<String, PhysicalDbGroup> newDbGroups) {
+        if (newDbGroups.isEmpty()) {
+            return;
+        }
+        for (PhysicalDbGroup dbGroup : newDbGroups.values()) {
+            checkDbGroupVersion(dbGroup);
+        }
+    }
+
+    public static void checkDbGroupVersion(PhysicalDbGroup dbGroup) {
+        for (PhysicalDbInstance ds : dbGroup.getAllDbInstanceMap().values()) {
+            if (ds.isDisabled() || !ds.isTestConnSuccess() || ds.isFakeNode()) {
+                continue;
+            }
+            //check mysql version
+            checkMysqlVersion(ds.getDsVersion(), ds, true);
+        }
     }
 
     protected static class VariableMapKey {

--- a/src/main/java/com/actiontech/dble/services/manager/response/DryRun.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/DryRun.java
@@ -108,6 +108,16 @@ public final class DryRun {
                     LOGGER.debug("[dry-run] test connection, catch exception", e);
                 }
             }
+
+            try {
+                LOGGER.info("[dry-run] check dble and mysql version start");
+                //check version
+                ConfigUtil.checkDbleAndMysqlVersion(loader.getDbGroups());
+            } catch (Exception e) {
+                LOGGER.debug("[dry-run] check dble and mysql version, catch exception:", e);
+                list.add(new ErrorInfo("Backend", "ERROR", "check dble and mysql version exception: " + e.getMessage()));
+            }
+
             try {
                 LOGGER.info("[dry-run] check and get system variables from backend start");
                 List<String> syncKeyVariables = ConfigUtil.getAndSyncKeyVariables(loader.getDbGroups(), false);

--- a/src/main/java/com/actiontech/dble/services/manager/response/ReloadConfig.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/ReloadConfig.java
@@ -333,14 +333,18 @@ public final class ReloadConfig {
         ReloadLogHelper.briefInfo("check and get system variables from random node start");
         SystemVariables newSystemVariables;
         if (forceAllReload) {
-            //check version/packetSize/lowerCase
+            //check version
+            ConfigUtil.checkDbleAndMysqlVersion(newDbGroups);
+            //check packetSize/lowerCase
             ConfigUtil.getAndSyncKeyVariables(newDbGroups, true);
-            //system variables
+            //get system variables
             newSystemVariables = getSystemVariablesFromdbGroup(loader, newDbGroups);
         } else {
-            //check version/packetSize/lowerCase
+            //check version
+            ConfigUtil.checkDbleAndMysqlVersion(changeItemList, loader);
+            //check packetSize/lowerCase
             ConfigUtil.getAndSyncKeyVariables(changeItemList, true);
-            //system variables
+            //get system variables
             newSystemVariables = getSystemVariablesFromdbGroup(loader, loader.getDbGroups());
         }
         ReloadLogHelper.briefInfo("check and get system variables from random node end");
@@ -520,12 +524,14 @@ public final class ReloadConfig {
                         changeItem.setAffectTestConn(true);
                     } else {
                         newDbInstance.setTestConnSuccess(oldDbInstance.isTestConnSuccess());
+                        newDbInstance.setDsVersion(oldDbInstance.getDsVersion());
                     }
                     return changeItem;
                 }).forEach(changeItemList::add);
                 //testConnSuccess with both
                 for (Map.Entry<String, PhysicalDbInstance> dbInstanceEntry : dbInstanceMapDifference.entriesInCommon().entrySet()) {
                     dbInstanceEntry.getValue().setTestConnSuccess(oldDbInstanceMap.get(dbInstanceEntry.getKey()).isTestConnSuccess());
+                    dbInstanceEntry.getValue().setDsVersion(oldDbInstanceMap.get(dbInstanceEntry.getKey()).getDsVersion());
                 }
 
             }


### PR DESCRIPTION
Reason:  
  BUG inner-2221
Type:  
  BUG
Influences：  
fix: peel version check module 
when modifying the rwSplitUser-dbGroup, it is also necessary to check the version
