### PR TITLE
fix: after the slow log queue is full, discard the subsequent records that need to be added(cherry-pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/btrace/provider/GeneralProvider.java
+++ b/src/main/java/com/actiontech/dble/btrace/provider/GeneralProvider.java
@@ -41,4 +41,13 @@ public final class GeneralProvider {
 
     public static void showTableByNodeUnitHandlerFinished() {
     }
+
+    public static void beforeSlowLogClose() {
+    }
+
+    public static void afterSlowLogClose() {
+    }
+
+    public static void runFlushLogTask() {
+    }
 }

--- a/src/main/java/com/actiontech/dble/config/model/SystemConfig.java
+++ b/src/main/java/com/actiontech/dble/config/model/SystemConfig.java
@@ -174,7 +174,7 @@ public final class SystemConfig {
     private int flushSlowLogPeriod = 1; //second
     private int flushSlowLogSize = 1000; //row
     private int sqlSlowTime = 100; //ms
-    private int slowQueueOverflowPolicy = 2;
+    private int slowQueueOverflowPolicy = 1;
 
     //general log
     private int enableGeneralLog = 0;

--- a/src/main/java/com/actiontech/dble/log/DailyRotateLogStore.java
+++ b/src/main/java/com/actiontech/dble/log/DailyRotateLogStore.java
@@ -5,6 +5,8 @@
 
 package com.actiontech.dble.log;
 
+import com.actiontech.dble.btrace.provider.GeneralProvider;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -137,6 +139,7 @@ public class DailyRotateLogStore {
         force(false);
         close();
 
+        GeneralProvider.afterSlowLogClose();
         File file;
         file = new File(fileName);
         file.renameTo(target);

--- a/src/main/java/com/actiontech/dble/server/status/SlowQueryLog.java
+++ b/src/main/java/com/actiontech/dble/server/status/SlowQueryLog.java
@@ -7,7 +7,6 @@ package com.actiontech.dble.server.status;
 
 import com.actiontech.dble.config.model.SystemConfig;
 import com.actiontech.dble.log.slow.SlowQueryLogProcessor;
-
 import com.actiontech.dble.server.trace.TraceResult;
 import com.actiontech.dble.services.mysqlsharding.ShardingService;
 import org.slf4j.Logger;
@@ -81,6 +80,10 @@ public final class SlowQueryLog {
 
     public void setFlushPeriod(int flushPeriod) {
         this.flushPeriod = flushPeriod;
+        if (this.enableSlowLog && processor != null) {
+            processor.cancelFlushLogTask();
+            processor.initFlushLogTask();
+        }
     }
 
     public int getFlushSize() {

--- a/src/main/java/com/actiontech/dble/server/trace/TraceResult.java
+++ b/src/main/java/com/actiontech/dble/server/trace/TraceResult.java
@@ -111,7 +111,7 @@ public class TraceResult implements Cloneable {
     public void setResponseTime(final ShardingService shardingService, boolean isSuccess) {
         if (this.requestEnd == null) {
             this.requestEnd = TraceRecord.currenTime();
-            if (this.isCompletedV1() &&
+            if (SlowQueryLog.getInstance().isEnableSlowLog() && this.isCompletedV1() &&
                     isSuccess && getOverAllMilliSecond() > SlowQueryLog.getInstance().getSlowTime()) {
                 SlowQueryLog.getInstance().putSlowQueryLog(shardingService, this.clone());
             }

--- a/src/main/java/com/actiontech/dble/services/manager/response/ReloadSlowQueryFlushPeriod.java
+++ b/src/main/java/com/actiontech/dble/services/manager/response/ReloadSlowQueryFlushPeriod.java
@@ -6,10 +6,10 @@
 package com.actiontech.dble.services.manager.response;
 
 import com.actiontech.dble.config.ErrorCode;
-import com.actiontech.dble.services.manager.ManagerService;
-import com.actiontech.dble.services.manager.handler.WriteDynamicBootstrap;
 import com.actiontech.dble.net.mysql.OkPacket;
 import com.actiontech.dble.server.status.SlowQueryLog;
+import com.actiontech.dble.services.manager.ManagerService;
+import com.actiontech.dble.services.manager.handler.WriteDynamicBootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public final class ReloadSlowQueryFlushPeriod {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReloadSlowQueryFlushPeriod.class);
 
     public static void execute(ManagerService service, int time) {
-        if (time < 0) {
+        if (time <= 0) {
             service.writeErrMessage(ErrorCode.ER_UNKNOWN_ERROR, "the commend is not correct");
             return;
         }

--- a/src/main/java/com/actiontech/dble/singleton/SystemParams.java
+++ b/src/main/java/com/actiontech/dble/singleton/SystemParams.java
@@ -192,7 +192,7 @@ public final class SystemParams {
         params.add(new ParamInfo("sqlSlowTime", SlowQueryLog.getInstance().getSlowTime() + "ms", "The threshold of Slow Query, the default is 100ms"));
         params.add(new ParamInfo("flushSlowLogPeriod", SlowQueryLog.getInstance().getFlushPeriod() + "s", "The period for flushing log to disk, the default is 1 second"));
         params.add(new ParamInfo("flushSlowLogSize", SlowQueryLog.getInstance().getFlushSize() + "", "The max size for flushing log to disk, the default is 1000"));
-        params.add(new ParamInfo("slowQueueOverflowPolicy", SlowQueryLog.getInstance().getQueueOverflowPolicy() + "", "Slow log queue overflow policy, the default is 2"));
+        params.add(new ParamInfo("slowQueueOverflowPolicy", SlowQueryLog.getInstance().getQueueOverflowPolicy() + "", "Slow log queue overflow policy, the default is 1"));
         params.add(new ParamInfo("enableAlert", AlertUtil.isEnable() ? "1" : "0", "Enable or disable alert"));
         params.add(new ParamInfo("capClientFoundRows", CapClientFoundRows.getInstance().isEnableCapClientFoundRows() + "", "Whether to turn on EOF_Packet to return found rows, the default value is false"));
         params.add(new ParamInfo("maxRowSizeToFile", LoadDataBatch.getInstance().getSize() + "", "The maximum row size,if over this value,row data will be saved to file when load data.The default value is 100000"));

--- a/src/main/resources/bootstrap_template.cnf
+++ b/src/main/resources/bootstrap_template.cnf
@@ -173,7 +173,7 @@
 #  the threshold for judging if the query is slow , unit is millisecond
 -DsqlSlowTime=100
 # slow log queue overflow policy
--DslowQueueOverflowPolicy=2
+-DslowQueueOverflowPolicy=1
 
 #  used for load data,maxCharsPerColumn means max chars length for per column when load data
 -DmaxCharsPerColumn=65535


### PR DESCRIPTION
Reason:
  BUG inner-2228/inner-2230
Type:
  BUG
Influences：
fix: after the slow log queue is full, discard the subsequent records that need to be added
after abnormal disk flush, fileChannel will not close
#3704