### PR TITLE
fix: rows that do not need to be changed are not correctly removed during update or delete(cherry-pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/services/manager/information/ManagerTableUtil.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/ManagerTableUtil.java
@@ -112,8 +112,8 @@ public final class ManagerTableUtil {
                     String value = null == row.getValue(i) ? null : new String(row.getValue(i), charset);
                     affectPk.put(columnName, value);
                     if (null != values) {
-                        boolean match = values.entrySet().stream().anyMatch(valueEntry -> !StringUtil.equals(affectPk.get(valueEntry.getKey()), valueEntry.getValue()));
-                        if (!match) {
+                        boolean isSkipRow = values.entrySet().stream().allMatch(valueEntry -> affectPk.containsKey(valueEntry.getKey()) && StringUtil.equals(affectPk.get(valueEntry.getKey()), valueEntry.getValue()));
+                        if (isSkipRow) {
                             breakFlag = true;
                             break;
                         }

--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbGroup.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbGroup.java
@@ -221,7 +221,7 @@ public class DbleDbGroup extends ManagerWritableTable {
             DbleRwSplitEntry dbleRwSplitEntry = (DbleRwSplitEntry) ManagerSchemaInfo.getInstance().getTables().get(DbleRwSplitEntry.TABLE_NAME);
             boolean existUser = dbleRwSplitEntry.getRows().stream().anyMatch(entry -> entry.get(DbleRwSplitEntry.COLUMN_DB_GROUP).equals(affectPk.get(COLUMN_NAME)));
             if (existUser) {
-                throw new ConfigException("Cannot delete or update a parent row: a foreign key constraint fails `dble_db_user`(`db_group`) REFERENCES `dble_db_group`(`name`)");
+                throw new ConfigException("Cannot delete or update a parent row: a foreign key constraint fails `dble_rw_split_entry`(`db_group`) REFERENCES `dble_db_group`(`name`)");
             }
             //check instance-group
             DbleDbInstance dbleDbInstance = (DbleDbInstance) ManagerSchemaInfo.getInstance().getTables().get(DbleDbInstance.TABLE_NAME);
@@ -260,18 +260,22 @@ public class DbleDbGroup extends ManagerWritableTable {
                     }
                 }
             }
-            String delayThresholdStr = row.get(COLUMN_DELAY_THRESHOLD);
-            String heartbeatTimeoutStr = row.get(COLUMN_HEARTBEAT_TIMEOUT);
-            String heartbeatRetryStr = row.get(COLUMN_HEARTBEAT_RETRY);
-            if (!StringUtil.isBlank(delayThresholdStr) && IntegerUtil.parseInt(delayThresholdStr) < -1) {
-                throw new ConfigException("Column '" + COLUMN_DELAY_THRESHOLD + "' should be an integer greater than or equal to -1!");
-            }
-            if (!StringUtil.isBlank(heartbeatTimeoutStr) && IntegerUtil.parseInt(heartbeatTimeoutStr) < 0) {
-                throw new ConfigException("Column '" + COLUMN_HEARTBEAT_TIMEOUT + "' should be an integer greater than or equal to 0!");
-            }
-            if (!StringUtil.isBlank(heartbeatRetryStr) && IntegerUtil.parseInt(heartbeatRetryStr) < 0) {
-                throw new ConfigException("Column '" + COLUMN_HEARTBEAT_RETRY + "' should be an integer greater than or equal to 0!");
-            }
+            checkInterValue(row);
+        }
+    }
+
+    private void checkInterValue(LinkedHashMap<String, String> row) {
+        String delayThresholdStr = row.get(COLUMN_DELAY_THRESHOLD);
+        String heartbeatTimeoutStr = row.get(COLUMN_HEARTBEAT_TIMEOUT);
+        String heartbeatRetryStr = row.get(COLUMN_HEARTBEAT_RETRY);
+        if (row.containsKey(COLUMN_DELAY_THRESHOLD) && (StringUtil.isBlank(delayThresholdStr) || IntegerUtil.parseInt(delayThresholdStr) < -1)) {
+            throw new ConfigException("Column '" + COLUMN_DELAY_THRESHOLD + "' should be an integer greater than or equal to -1!");
+        }
+        if (row.containsKey(COLUMN_HEARTBEAT_TIMEOUT) && (StringUtil.isBlank(heartbeatTimeoutStr) || IntegerUtil.parseInt(heartbeatTimeoutStr) < 0)) {
+            throw new ConfigException("Column '" + COLUMN_HEARTBEAT_TIMEOUT + "' should be an integer greater than or equal to 0!");
+        }
+        if (row.containsKey(COLUMN_HEARTBEAT_RETRY) && (StringUtil.isBlank(heartbeatRetryStr) || IntegerUtil.parseInt(heartbeatRetryStr) < 0)) {
+            throw new ConfigException("Column '" + COLUMN_HEARTBEAT_RETRY + "' should be an integer greater than or equal to 0!");
         }
     }
 

--- a/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbInstance.java
+++ b/src/main/java/com/actiontech/dble/services/manager/information/tables/DbleDbInstance.java
@@ -402,6 +402,8 @@ public class DbleDbInstance extends ManagerWritableTable {
         DBInstance dbInstance = new DBInstance();
         StringBuilder url = new StringBuilder();
         List<Property> propertyList = Lists.newArrayList();
+        String key;
+        String entryValue;
         for (Map.Entry<String, String> entry : map.entrySet()) {
             switch (entry.getKey()) {
                 case COLUMN_NAME:
@@ -469,6 +471,13 @@ public class DbleDbInstance extends ManagerWritableTable {
                 case COLUMN_TEST_ON_BORROW:
                 case COLUMN_TEST_ON_RETURN:
                 case COLUMN_TEST_WHILE_IDLE:
+                    key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, entry.getKey());
+                    entryValue = entry.getValue();
+                    if (StringUtil.isBlank(entryValue) || (!StringUtil.equalsIgnoreCase(entryValue, Boolean.FALSE.toString()) && !StringUtil.equalsIgnoreCase(entryValue, Boolean.TRUE.toString()))) {
+                        throw new ConfigException("Column '" + entry.getKey() + "' values only support 'false' or 'true'.");
+                    }
+                    propertyList.add(new Property(entryValue, key));
+                    break;
                 case COLUMN_CONNECTION_TIMEOUT:
                 case COLUMN_CONNECTION_HEARTBEAT_TIMEOUT:
                 case COLUMN_TIME_BETWEEN_EVICTION_RUNS_MILLIS:
@@ -477,8 +486,12 @@ public class DbleDbInstance extends ManagerWritableTable {
                 case COLUMN_EVICTOR_SHUTDOWN_TIMEOUT_MILLIS:
                 case COLUMN_FLOW_HIGH_LEVEL:
                 case COLUMN_FLOW_LOW_LEVEL:
-                    String key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, entry.getKey());
-                    propertyList.add(new Property(entry.getValue(), key));
+                    key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, entry.getKey());
+                    entryValue = entry.getValue();
+                    if (StringUtil.isBlank(entryValue) || IntegerUtil.parseInt(entryValue) <= 0) {
+                        throw new ConfigException("Column '" + entry.getKey() + "' should be an integer greater than 0!");
+                    }
+                    propertyList.add(new Property(entryValue, key));
                     break;
                 default:
                     break;


### PR DESCRIPTION
Reason:  
  BUG inner-2283/#3763
Type:  
  BUG
Influences：  
fix: rows that do not need to be changed are not correctly removed during update or delete
