### PR TITLE
fix: after the slow log queue is full, discard the subsequent records that need to be added(cherry-pick) 

### DIFF
--- a/src/main/java/com/actiontech/dble/btrace/provider/GeneralProvider.java
+++ b/src/main/java/com/actiontech/dble/btrace/provider/GeneralProvider.java
@@ -1,0 +1,14 @@
+package com.actiontech.dble.btrace.provider;
+
+public final class GeneralProvider {
+    private GeneralProvider() {
+    }
+    public static void beforeSlowLogClose() {
+    }
+
+    public static void afterSlowLogClose() {
+    }
+
+    public static void runFlushLogTask() {
+    }
+}

--- a/src/main/java/com/actiontech/dble/log/DailyRotateLogStore.java
+++ b/src/main/java/com/actiontech/dble/log/DailyRotateLogStore.java
@@ -5,6 +5,8 @@
 
 package com.actiontech.dble.log;
 
+import com.actiontech.dble.btrace.provider.GeneralProvider;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -148,6 +150,7 @@ public class DailyRotateLogStore {
         force(false);
         close();
 
+        GeneralProvider.afterSlowLogClose();
         File file;
         file = new File(fileName);
         file.renameTo(target);

--- a/src/main/java/com/actiontech/dble/manager/response/ReloadSlowQueryFlushPeriod.java
+++ b/src/main/java/com/actiontech/dble/manager/response/ReloadSlowQueryFlushPeriod.java
@@ -19,7 +19,7 @@ public final class ReloadSlowQueryFlushPeriod {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReloadSlowQueryFlushPeriod.class);
 
     public static void execute(ManagerConnection c, int time) {
-        if (time < 0) {
+        if (time <= 0) {
             c.writeErrMessage(ErrorCode.ER_UNKNOWN_ERROR, "the commend is not correct");
             return;
         }

--- a/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
+++ b/src/main/java/com/actiontech/dble/server/NonBlockingSession.java
@@ -328,7 +328,7 @@ public class NonBlockingSession implements Session {
         if (traceEnable || SlowQueryLog.getInstance().isEnableSlowLog()) {
             responseTime = System.nanoTime();
             traceResult.setVeryEnd(responseTime);
-            if (isSuccess) {
+            if (isSuccess && SlowQueryLog.getInstance().isEnableSlowLog()) {
                 SlowQueryLog.getInstance().putSlowQueryLog(this.source, (TraceResult) traceResult.clone());
             }
         }

--- a/src/main/java/com/actiontech/dble/server/status/SlowQueryLog.java
+++ b/src/main/java/com/actiontech/dble/server/status/SlowQueryLog.java
@@ -70,6 +70,10 @@ public final class SlowQueryLog {
 
     public void setFlushPeriod(int flushPeriod) {
         this.flushPeriod = flushPeriod;
+        if (this.enableSlowLog && processor != null) {
+            processor.cancelFlushLogTask();
+            processor.initFlushLogTask();
+        }
     }
 
     public int getFlushSize() {


### PR DESCRIPTION
Reason:
  BUG inner-2230
Type:
  BUG
Influences：
fix: after the slow log queue is full, discard the subsequent records that need to be added
after abnormal disk flush, fileChannel will not close
#3704