### PR TITLE
[inner-2339] fix: create connection timeout check should exclude connections in use (cherry-pick)

### DIFF
--- a/src/main/java/com/actiontech/dble/net/IOProcessor.java
+++ b/src/main/java/com/actiontech/dble/net/IOProcessor.java
@@ -189,10 +189,10 @@ public final class IOProcessor {
             }
             long cost = System.currentTimeMillis() - c.getStartupTime();
 
-            // a connection in change user
             if (c.getService() instanceof MySQLBackAuthService) {
                 //when the connection creation time is greater than the connectionTimeout, it is a network timeout
-                if (cost >= c.getConnectionTimeout()) {
+                //except for the scenario of changing user,see it:com.actiontech.dble.services.mysqlsharding.MySQLResponseService.changeUser
+                if (c.getState() != PooledConnection.STATE_IN_USE && cost >= c.getConnectionTimeout()) {
                     c.close("Create connection timed out");
                 }
                 continue;


### PR DESCRIPTION
Reason:
  BUG inner-2339
Type:
  BUG
Influences：
create connection timeout check should exclude connections in use (changeUser case)
#3815 